### PR TITLE
Add warning about unknown proof types to Security Considerations.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2728,7 +2728,7 @@ that it does not explicitly know it can safely present. Any
 safely present can remain. For example, a digital wallet that can verify
 an `ecdsa-rdfc-2019`
 [=data integrity proof|proof=], but not an `ecdsa-jcs-2019` [=data integrity
-proof|proof=] can still present either. Other [=data integrity proof|proofs=],
+proof|proof=], can still present either. Other [=data integrity proof|proofs=],
 such as those that offer [=selective disclosure=] and / or [=unlinkable
 disclosure=] features require
 <a data-cite="?VC-DATA-INTEGRITY#transformation">transformation</a> (that is, a


### PR DESCRIPTION
This PR is an attempt to address issue #543 by adding a warning about unknown proof types to Security Considerations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vcalm/pull/555.html" title="Last updated on Oct 5, 2025, 7:57 PM UTC (45e1593)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vcalm/555/2a522e0...45e1593.html" title="Last updated on Oct 5, 2025, 7:57 PM UTC (45e1593)">Diff</a>