### PR TITLE
Updated GetExchangeResponse object

### DIFF
--- a/oas.yaml
+++ b/oas.yaml
@@ -891,18 +891,7 @@ components:
     GetExchangeResponse:
       type: object
       additionalProperties: false
-      description: Object containing information about an active exchange.
-      oneOf:
-      - $ref: "#/components/schemas/ExchangeResponse"
-      - type: object
-        properties:
-          emptyExchangeResponse:
-            type: object
-            description: An empty object sent by either party in an exchange terminates the exchange. 
-    ExchangeResponse:
-      type: object
-      additionalProperties: false
-      description: Object containing information about an active exchange.
+      description: Object containing information about an active exchange. This can be an empty object when a given exchange has no VP and no redirectUrl to send.
       properties:
         id:
           type: string


### PR DESCRIPTION
Added a secondary option to the GetExchangeResponse object that indicates that an exchange can be responded to with an empty object to terminate the exchange. As part of this a new ExchangeResponse object was created to be referenced by GetExchangeResponse.

Attempt to handle https://github.com/w3c-ccg/vcalm/issues/553