### PR TITLE
Detailing how selective disclosure works in Query By Example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1288,9 +1288,9 @@ the [=verifier=].
           To request a field without any statement about an expected value, a requester can include the field in 
           the request and leave the value as an empty string. For instance, if a requester needs a first name, 
           they could include the optional "`credentialSubject`" object with a single field, `"firstName": ""`. 
-          This would allow a wallet to respond with only the firstName of the requested credential with no expectation 
-          of any other field being included. This does not prevent a wallet from oversharing and including additional 
-          fields in its response to the query.
+          This would allow a wallet to respond with only the `firstName` of the requested credential with no expectation 
+          of any other field being included. _This does not prevent a wallet from oversharing by including additional 
+          fields in its response to the query._
         </p>
         
       </section>


### PR DESCRIPTION
Added a note in the Query By Example section detailing how Query By Example enables selective disclosure.

This PR is being raised to address https://github.com/w3c-ccg/vcalm/issues/544


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eric-schuh/vcalm/pull/570.html" title="Last updated on Dec 16, 2025, 8:26 PM UTC (2f4a10b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vcalm/570/52372b2...eric-schuh:2f4a10b.html" title="Last updated on Dec 16, 2025, 8:26 PM UTC (2f4a10b)">Diff</a>