### PR TITLE
Add an example interaction scheme format URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -2860,31 +2860,35 @@ format for this purpose. The format of the protocol scheme MUST conform to
 the following syntax:
         </p>
 
-      <table class="simple">
-        <thead>
-          <tr>
-            <th>
-The Interaction Protocol Scheme
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <pre class="nohighlight">
-scheme          = "interaction:" interaction-url
-interaction-url = <a href="https://url.spec.whatwg.org/#concept-url">URL</a>
-              </pre>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+        <table class="simple">
+          <thead>
+            <tr>
+              <th>
+  The Interaction Protocol Scheme
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <pre class="nohighlight">
+  scheme          = "interaction:" interaction-url
+  interaction-url = <a href="https://url.spec.whatwg.org/#concept-url">URL</a>
+                </pre>
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
-      <p>
-The `interaction-url` is any URL that conforms to the [[[URL]]] and where
-retrieving the resource at the URL results in an
-<a href="#interaction-protocols-response">interaction protocols response</a>.
-      </p>
+        <p>
+  The `interaction-url` is any URL that conforms to the [[[URL]]] and where
+  retrieving the resource at the URL results in an
+  <a href="#interaction-protocols-response">interaction protocols response</a>.
+        </p>
+
+        <pre class="example nohighlight" title="An example of an interaction scheme URL">
+  interaction:https://app.example/interactions/z8n38Dp7a?iuv=1
+        </pre>
 
       </section>
 


### PR DESCRIPTION
Adds an interaction scheme format URL example.

Looked like the indentation wasn't quite correct in this section as well, but I may be missing something about how these documents are indented on quick inspection.

Resolves #601 