### PR TITLE
Use generic object without results for create exchange variables.

### DIFF
--- a/oas.yaml
+++ b/oas.yaml
@@ -1151,7 +1151,7 @@ components:
               variables:
                 oneOf:
                   - type: string
-                  - $ref: "#/components/schemas/GetExchangeVariables"
+                  - $ref: "#/components/schemas/CreateExchangeVariables"
             oneOf:
               - required:
                   - credentialTemplateId


### PR DESCRIPTION
This PR addresses Issue #599 by removing the `results` field from the `variables` object in the request body schema of the create exchange endpoint.