### PR TITLE
Update name for Recognized Entities spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,11 +71,11 @@
         status: "WD",
         publisher: "OpenID Foundation"
       },
-      "VC-RECOGNITION": {
-        title: "Verifiable Credentials for Entity Recognition v1.0",
-        href: "https://w3c.github.io/vc-recognition/",
+      "VC-RECOG-ENT": {
+        title: "Recognized Entities v1.0",
+        href: "https://www.w3.org/TR/vc-recognized-entities/",
         status: "WD",
-        publisher: "W3C Credentials Community Group"
+        publisher: "W3C"
       }
     },
     xref: [
@@ -1404,8 +1404,8 @@ or 2) an object that contains an `id` property whose value is a [[URL]] that
 identifies an [=issuer=] in the `issuer` property of the received [=verifiable
 credential=], or 3) an object that contains a `recognizedIn` property that is
 associated with an object with a `type` property that is set to
-`VerifiableRecognitionCredential` and an `id` property with a [[URL]] value that
-points to such a credential as defined in the [[[VC-RECOGNITION]]]
+`RecognizedEntityCredential` and an `id` property with a [[URL]] value that
+points to such a credential as defined in the [[[VC-RECOG-ENT]]]
 specification; the list contains recognized issuers that are acceptable to the
 [=verifier=]. Valid example values include:
 
@@ -1413,7 +1413,7 @@ specification; the list contains recognized issuers that are acceptable to the
   <li>`did:web:red-issuer.example`</li>
   <li>`https://blue-issuer.example/`</li>
   <li>`{"id": "did:web:green-issuer.example"}`</li>
-  <li>`{"recognizedIn": {"id": "https://url.example/list.vc", "type": "VerifiableRecognitionCredential"}}`</li>
+  <li>`{"recognizedIn": {"id": "https://url.example/list.vc", "type": "RecognizedEntityCredential"}}`</li>
 </ul>
             </td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
       }
     },
     xref: [
-      "web-platform", "infra", "url", "vc-data-model-2.0", "did", "vc-data-integrity"
+      "web-platform", "infra", "url", "vc-data-model-2.0", "did", "vc-data-integrity", "vc-recognized-entities"
     ],
     github: {
       repoURL: "https://github.com/w3c/vcalm/",


### PR DESCRIPTION
This PR addresses Issue #616 by updating name and type references related to the Recognized Entities spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 23, 2026, 8:08 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=respec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fkezike%2Fvcalm%2F57ffc10421c11805391709b5bf3370e6109d22a1%2Findex.html%3FisPreview%3Dtrue)

**Error output:**

```
EISDIR: illegal operation on a directory, open 'uploads/ELzm94/'
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/vcalm%23650.)._

</details>
