### PR TITLE
Clarify when to use `acceptedEnvelopes` and `acceptedCryptosuites`

### DIFF
--- a/components/VerifiablePresentationRequest.yml
+++ b/components/VerifiablePresentationRequest.yml
@@ -47,7 +47,7 @@ components:
                           type: string
                   "acceptedCryptosuites":
                     type: array
-                    description: Cryptographic proof suites the verifier will accept. Each element SHOULD be an object with a `cryptosuite` property; however, for backwards compatibility, string values are also accepted and interpreted as the cryptosuite name for a Data Integrity proof.
+                    description: Cryptographic proof suites the verifier will accept. Each element SHOULD be an object with a <code>cryptosuite</code> property; however, for backwards compatibility, string values are also accepted and interpreted as the cryptosuite name for a Data Integrity proof. This enables the holder to select an appropriate proof format. The presence of this property SHOULD be mutually exclusive with that of <code>acceptedEnvelopes</code>, which is only applicable to enveloped credentials.
                     items:
                       oneOf:
                         - type: string
@@ -61,7 +61,7 @@ components:
                           example: [{"cryptosuite": "eddsa-rdfc-2022"}, {"cryptosuite": "bbs-2023"}, {"cryptosuite": "ecdsa-sd-2023"}]
                   "acceptedEnvelopes":
                     type: array
-                    description: Envelope formats the verifier will accept. Each element SHOULD be an object with a `mediaType` property; however, for backwards compatibility, string values are also accepted and interpreted as the media type for the envelope.
+                    description: Envelope formats the verifier will accept. Each element SHOULD be an object with a <code>mediaType</code> property; however, for backwards compatibility, string values are also accepted and interpreted as the media type for the envelope. This enables the holder to provide credentials in formats other than the default Data Integrity format. The presence of this property SHOULD be mutually exclusive with that of <code>acceptedCryptosuites</code>, which is only applicable to JSON-LD credentials signed with a Data Integrity cryptosuite.
                     items:
                       oneOf:
                         - type: string

--- a/components/VerifiablePresentationRequest.yml
+++ b/components/VerifiablePresentationRequest.yml
@@ -47,21 +47,21 @@ components:
                           type: string
                   "acceptedCryptosuites":
                     type: array
-                    description: Cryptographic proof suites the verifier will accept. Each element SHOULD be an object with a <code>cryptosuite</code> property; however, for backwards compatibility, string values are also accepted and interpreted as the cryptosuite name for a Data Integrity proof. This enables the holder to select an appropriate proof format. The presence of this property SHOULD be mutually exclusive with that of <code>acceptedEnvelopes</code>, which is only applicable to enveloped credentials.
+                    description: Cryptographic proof suites the verifier will accept. Each element SHOULD be an object with a <code>cryptosuite</code> property referencing a Data Integrity cryptosuite name or <code>Ed25519Signature2020</code>. However, for backwards compatibility, string values are also accepted and interpreted as the cryptosuite name. This enables the holder to select an appropriate proof format. This property MAY be used independently of <code>acceptedEnvelopes</code>, which is only applicable to enveloped credentials.
                     items:
                       oneOf:
                         - type: string
                           description: A cryptosuite name (shorthand for an object with cryptosuite).
-                          example: ["eddsa-rdfc-2022", "bbs-2023", "ecdsa-sd-2023"]
+                          example: ["eddsa-rdfc-2022", "bbs-2023", "ecdsa-sd-2023", "Ed25519Signature2020"]
                         - type: object
                           properties:
                             "cryptosuite":
                               type: string
                               description: The name of the cryptosuite.
-                          example: [{"cryptosuite": "eddsa-rdfc-2022"}, {"cryptosuite": "bbs-2023"}, {"cryptosuite": "ecdsa-sd-2023"}]
+                          example: [{"cryptosuite": "eddsa-rdfc-2022"}, {"cryptosuite": "bbs-2023"}, {"cryptosuite": "ecdsa-sd-2023"}, {"cryptosuite": "Ed25519Signature2020"}]
                   "acceptedEnvelopes":
                     type: array
-                    description: Envelope formats the verifier will accept. Each element SHOULD be an object with a <code>mediaType</code> property; however, for backwards compatibility, string values are also accepted and interpreted as the media type for the envelope. This enables the holder to provide credentials in formats other than the default Data Integrity format. The presence of this property SHOULD be mutually exclusive with that of <code>acceptedCryptosuites</code>, which is only applicable to JSON-LD credentials signed with a Data Integrity cryptosuite.
+                    description: Envelope formats the verifier will accept. Each element SHOULD be an object with a <code>mediaType</code> property referencing the media type for the envelope. However, for backwards compatibility, string values are also accepted and interpreted as the media type. This enables the holder to provide credentials in formats other than the default Data Integrity format. This property MAY be used independently of <code>acceptedCryptosuites</code>, which is only applicable to JSON-LD credentials signed with an acceptable cryptosuite.
                     items:
                       oneOf:
                         - type: string

--- a/components/VerifiablePresentationRequest.yml
+++ b/components/VerifiablePresentationRequest.yml
@@ -47,7 +47,7 @@ components:
                           type: string
                   "acceptedCryptosuites":
                     type: array
-                    description: Cryptographic proof suites the verifier will accept. Each element SHOULD be an object with a <code>cryptosuite</code> property referencing a Data Integrity cryptosuite name or <code>Ed25519Signature2020</code>. However, for backwards compatibility, string values are also accepted and interpreted as the cryptosuite name. This enables the holder to select an appropriate proof format. This property MAY be used independently of <code>acceptedEnvelopes</code>, which is only applicable to enveloped credentials.
+                    description: Cryptographic proof suites the verifier will accept. Each element SHOULD be an object with a <code>cryptosuite</code> property referencing a Data Integrity cryptosuite name or <code>Ed25519Signature2020</code> for legacy (for backwards compatibility, string values are also accepted and interpreted as the cryptosuite name). This enables the holder to select an appropriate proof format. This property MAY be used independently of <code>acceptedEnvelopes</code>, which is only applicable to enveloped credentials.
                     items:
                       oneOf:
                         - type: string
@@ -61,7 +61,7 @@ components:
                           example: [{"cryptosuite": "eddsa-rdfc-2022"}, {"cryptosuite": "bbs-2023"}, {"cryptosuite": "ecdsa-sd-2023"}, {"cryptosuite": "Ed25519Signature2020"}]
                   "acceptedEnvelopes":
                     type: array
-                    description: Envelope formats the verifier will accept. Each element SHOULD be an object with a <code>mediaType</code> property referencing the media type for the envelope. However, for backwards compatibility, string values are also accepted and interpreted as the media type. This enables the holder to provide credentials in formats other than the default Data Integrity format. This property MAY be used independently of <code>acceptedCryptosuites</code>, which is only applicable to JSON-LD credentials signed with an acceptable cryptosuite.
+                    description: Envelope formats the verifier will accept. Each element SHOULD be an object with a <code>mediaType</code> property referencing the media type for the envelope (for backwards compatibility, string values are also accepted and interpreted as the media type). This enables the holder to provide credentials in formats other than the default Data Integrity format. This property MAY be used independently of <code>acceptedCryptosuites</code>, which is only applicable to JSON-LD credentials signed with an acceptable cryptosuite.
                     items:
                       oneOf:
                         - type: string

--- a/components/VerifiablePresentationRequest.yml
+++ b/components/VerifiablePresentationRequest.yml
@@ -47,7 +47,7 @@ components:
                           type: string
                   "acceptedCryptosuites":
                     type: array
-                    description: Cryptographic proof suites the verifier will accept. Each element SHOULD be an object with a <code>cryptosuite</code> property referencing a Data Integrity cryptosuite name or <code>Ed25519Signature2020</code> for legacy (for backwards compatibility, string values are also accepted and interpreted as the cryptosuite name). This enables the holder to select an appropriate proof format. This property MAY be used independently of <code>acceptedEnvelopes</code>, which is only applicable to enveloped credentials.
+                    description: Cryptographic proof suites the verifier will accept. Each element SHOULD be an object with a <code>cryptosuite</code> property referencing a Data Integrity cryptosuite name or <code>Ed25519Signature2020</code> for legacy (for backwards compatibility, string values MAY also be used and are to be interpreted as the cryptosuite name). This enables the holder to select an appropriate proof format. This property MAY be used independently of <code>acceptedEnvelopes</code>, which is only applicable to enveloped credentials.
                     items:
                       oneOf:
                         - type: string
@@ -61,7 +61,7 @@ components:
                           example: [{"cryptosuite": "eddsa-rdfc-2022"}, {"cryptosuite": "bbs-2023"}, {"cryptosuite": "ecdsa-sd-2023"}, {"cryptosuite": "Ed25519Signature2020"}]
                   "acceptedEnvelopes":
                     type: array
-                    description: Envelope formats the verifier will accept. Each element SHOULD be an object with a <code>mediaType</code> property referencing the media type for the envelope (for backwards compatibility, string values are also accepted and interpreted as the media type). This enables the holder to provide credentials in formats other than the default Data Integrity format. This property MAY be used independently of <code>acceptedCryptosuites</code>, which is only applicable to JSON-LD credentials signed with an acceptable cryptosuite.
+                    description: Envelope formats the verifier will accept. Each element SHOULD be an object with a <code>mediaType</code> property referencing the media type for the envelope (for backwards compatibility, string values MAY also be used and are to be interpreted as the media type). This enables the holder to provide credentials in formats other than the default Data Integrity format. This property MAY be used independently of <code>acceptedCryptosuites</code>, which is only applicable to JSON-LD credentials signed with an acceptable cryptosuite.
                     items:
                       oneOf:
                         - type: string

--- a/index.html
+++ b/index.html
@@ -1424,7 +1424,9 @@ An OPTIONAL array specifying which cryptographic proof suites the [=verifier=]
 will accept. Each element SHOULD be an object with a <code>cryptosuite</code>
 property; however, for backwards compatibility, string values are also accepted
 and interpreted as the cryptosuite name for a Data Integrity proof. This enables
-the [=holder=] to select an appropriate proof format. Valid example values include:
+the [=holder=] to select an appropriate proof format. The presence of this property
+SHOULD be mutually exclusive with that of <code>acceptedEnvelopes</code>,
+which is only applicable to enveloped credentials. Valid example values include:
 <ul>
   <li><code>[{"cryptosuite": "eddsa-rdfc-2022"}, {"cryptosuite": "ecdsa-rdfc-2019"}]</code></li>
   <li><code>[{"cryptosuite": "bbs-2023"}, {"cryptosuite": "ecdsa-sd-2023"}]</code></li>
@@ -1439,7 +1441,9 @@ accept. Each element SHOULD be an object with a <code>mediaType</code> property;
 however, for backwards compatibility, string values are also accepted and
 interpreted as the media type for the envelope. This enables the [=holder=] to
 provide credentials in formats other than the default Data Integrity format.
-Valid example values include:
+The presence of this property SHOULD be mutually exclusive with that of
+<code>acceptedCryptosuites</code>, which is only applicable to JSON-LD credentials
+signed with a Data Integrity cryptosuite. Valid example values include:
 <ul>
   <li><code>[{"mediaType": "application/jwt"}]</code></li>
   <li><code>[{"mediaType": "application/vc+sd-jwt"}]</code></li>

--- a/index.html
+++ b/index.html
@@ -1422,10 +1422,10 @@ specification; the list contains recognized issuers that are acceptable to the
             <td>
 An OPTIONAL array specifying which cryptographic proof suites the [=verifier=]
 will accept. Each element SHOULD be an object with a <code>cryptosuite</code>
-property; however, for backwards compatibility, string values are also accepted
-and interpreted as the cryptosuite name for a Data Integrity proof. This enables
-the [=holder=] to select an appropriate proof format. The presence of this property
-SHOULD be mutually exclusive with that of <code>acceptedEnvelopes</code>,
+property referencing a Data Integrity cryptosuite name or <code>Ed25519Signature2020</code>.
+However, for backwards compatibility, string values are also accepted and
+interpreted as the cryptosuite name. This enables the [=holder=] to select an
+appropriate proof format. This property MAY be used independently of <code>acceptedEnvelopes</code>,
 which is only applicable to enveloped credentials. Valid example values include:
 <ul>
   <li><code>[{"cryptosuite": "eddsa-rdfc-2022"}, {"cryptosuite": "ecdsa-rdfc-2019"}]</code></li>
@@ -1437,13 +1437,14 @@ which is only applicable to enveloped credentials. Valid example values include:
             <td>acceptedEnvelopes</td>
             <td>
 An OPTIONAL array specifying which envelope formats the [=verifier=] will
-accept. Each element SHOULD be an object with a <code>mediaType</code> property;
-however, for backwards compatibility, string values are also accepted and
-interpreted as the media type for the envelope. This enables the [=holder=] to
+accept. Each element SHOULD be an object with a <code>mediaType</code>
+property referencing the media type for the envelope.
+However, for backwards compatibility, string values are also accepted and
+interpreted as the media type. This enables the [=holder=] to
 provide credentials in formats other than the default Data Integrity format.
-The presence of this property SHOULD be mutually exclusive with that of
-<code>acceptedCryptosuites</code>, which is only applicable to JSON-LD credentials
-signed with a Data Integrity cryptosuite. Valid example values include:
+This property MAY be used independently of <code>acceptedCryptosuites</code>,
+which is only applicable to JSON-LD credentials
+signed with an acceptable cryptosuite. Valid example values include:
 <ul>
   <li><code>[{"mediaType": "application/jwt"}]</code></li>
   <li><code>[{"mediaType": "application/vc+sd-jwt"}]</code></li>

--- a/index.html
+++ b/index.html
@@ -1423,7 +1423,7 @@ specification; the list contains recognized issuers that are acceptable to the
 An OPTIONAL array specifying which cryptographic proof suites the [=verifier=]
 will accept. Each element SHOULD be an object with a <code>cryptosuite</code>
 property referencing a Data Integrity cryptosuite name or <code>Ed25519Signature2020</code> for legacy
-(for backwards compatibility, string values are also accepted and
+(for backwards compatibility, string values MAY also be used and are to be
 interpreted as the cryptosuite name). This enables the [=holder=] to select an
 appropriate proof format. This property MAY be used independently of <code>acceptedEnvelopes</code>,
 which is only applicable to enveloped credentials. Valid example values include:
@@ -1439,7 +1439,7 @@ which is only applicable to enveloped credentials. Valid example values include:
 An OPTIONAL array specifying which envelope formats the [=verifier=] will
 accept. Each element SHOULD be an object with a <code>mediaType</code>
 property referencing the media type for the envelope
-(for backwards compatibility, string values are also accepted and
+(for backwards compatibility, string values MAY also be used and are to be
 interpreted as the media type). This enables the [=holder=] to
 provide credentials in formats other than the default Data Integrity format.
 This property MAY be used independently of <code>acceptedCryptosuites</code>,

--- a/index.html
+++ b/index.html
@@ -1422,9 +1422,9 @@ specification; the list contains recognized issuers that are acceptable to the
             <td>
 An OPTIONAL array specifying which cryptographic proof suites the [=verifier=]
 will accept. Each element SHOULD be an object with a <code>cryptosuite</code>
-property referencing a Data Integrity cryptosuite name or <code>Ed25519Signature2020</code>.
-However, for backwards compatibility, string values are also accepted and
-interpreted as the cryptosuite name. This enables the [=holder=] to select an
+property referencing a Data Integrity cryptosuite name or <code>Ed25519Signature2020</code> for legacy
+(for backwards compatibility, string values are also accepted and
+interpreted as the cryptosuite name). This enables the [=holder=] to select an
 appropriate proof format. This property MAY be used independently of <code>acceptedEnvelopes</code>,
 which is only applicable to enveloped credentials. Valid example values include:
 <ul>
@@ -1438,9 +1438,9 @@ which is only applicable to enveloped credentials. Valid example values include:
             <td>
 An OPTIONAL array specifying which envelope formats the [=verifier=] will
 accept. Each element SHOULD be an object with a <code>mediaType</code>
-property referencing the media type for the envelope.
-However, for backwards compatibility, string values are also accepted and
-interpreted as the media type. This enables the [=holder=] to
+property referencing the media type for the envelope
+(for backwards compatibility, string values are also accepted and
+interpreted as the media type). This enables the [=holder=] to
 provide credentials in formats other than the default Data Integrity format.
 This property MAY be used independently of <code>acceptedCryptosuites</code>,
 which is only applicable to JSON-LD credentials
@@ -1622,8 +1622,9 @@ An optional array of objects that conveys the cryptography suites among which
 the [=holder=] MUST choose when generating a cryptographic proof to be
 submitted to this [=verifier=]. Each object in the
 array MUST contain a property called `cryptosuite` with a value that is a
-cryptosuite name, and MAY contain other properties that are specific to the
-cryptosuite. Valid example values include:
+Data Integrity cryptosuite name (or `Ed25519Signature2020` for legacy),
+and MAY contain other properties that are specific to the cryptosuite.
+Valid example values include:
 <ul>
   <li>
 <code>[{"cryptosuite": "eddsa-rdfc-2022"}]</code>

--- a/oas.yaml
+++ b/oas.yaml
@@ -701,7 +701,7 @@ paths:
        - Verifier Coordinator
        - Workflow Service
       x-componentTableLink: "create-challenge"
-      description: Creates a challenge to be used as `options.challenge` in future requests.
+      description: Creates a challenge to be used as <code>options.challenge</code> in future requests.
       responses:
         "200":
           description: Challenge created
@@ -935,7 +935,7 @@ components:
                   description: OAuth2 issuer config URL.
         credentialTemplates:
           type: array
-          description: One or more templates for credential issuance. The `template` string should render to an object containing a "credential" field, which holds the credential template, and (optionally) an "options" field, which holds important credential issuing parameters (this is the format of the request body that is sent to POST /credentials/issue). Passing credentialTemplates is OPTIONAL.
+          description: One or more templates for credential issuance. The <code>template</code> string should render to an object containing a <code>credential</code> field, which holds the credential template, and (optionally) an <code>options</code> field, which holds important credential issuing parameters (this is the format of the request body that is sent to <code>POST /credentials/issue</code>). Passing <code>credentialTemplates</code> is OPTIONAL.
           items:
             type: object
             properties:
@@ -984,7 +984,7 @@ components:
                   description: OAuth2 issuer config URL.
         credentialTemplates:
           type: array
-          description: One or more templates for credential issuance. The `template` string should render to an object containing a "credential" field, which holds the credential template, and (optionally) an "options" field, which holds important credential issuing parameters (this is the format of the request body that is sent to POST /credentials/issue). Passing credentialTemplates is OPTIONAL.
+          description: One or more templates for credential issuance. The <code>template</code> string should render to an object containing a <code>credential</code> field, which holds the credential template, and (optionally) an <code>options</code> field, which holds important credential issuing parameters (this is the format of the request body that is sent to <code>POST /credentials/issue</code>). Passing <code>credentialTemplates</code> is OPTIONAL.
           items:
             type: object
             properties:


### PR DESCRIPTION
This PR addresses Issue #629 by providing guidance on when a VPR should include `acceptedEnvelopes` or `acceptedCryptosuites`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 30, 2026, 11:02 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=respec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fkezike%2Fvcalm%2F624b3dd89c8dec98c6653651e5d0c2b2e239b611%2Findex.html%3FisPreview%3Dtrue)

**Error output:**

```
EISDIR: illegal operation on a directory, open 'uploads/CMNNgv/'
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/vcalm%23651.)._

</details>
