### PR TITLE
Define valid ZCAP actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,12 @@
         href: "https://www.w3.org/TR/vc-recognized-entities/",
         status: "WD",
         publisher: "W3C"
+      },
+      "ZCAP": {
+        title: "Authorization Capabilities for Linked Data v0.3",
+        href: "https://w3c-ccg.github.io/zcap-spec/",
+        status: "WD",
+        publisher: "W3C Credentials Community Group"
       }
     },
     xref: [
@@ -854,6 +860,148 @@ a path within that domain (e.g., <code>website.example/api</code>).
   in those requests. An example of such a forbidden protocol is HTTP Basic
   Authentication [[RFC7617]].
           </p>
+        </section>
+
+        <section class="notoc">
+          <h4>Authorization Capabilities</h4>
+          <p>
+If Authorization Capabilities (zcaps) are used for authorization,
+the administrator SHOULD delegate a zcap with the appropriate
+format as defined in [[[ZCAP]]] and as required for the use case.
+This includes appropriate values for the controller, invocation target,
+and allowed actions, among other important properties.
+          </p>
+          <pre class="example nohighlight" title="VCALM Delegated Capability">
+{
+  "@context": [
+    "https://w3id.org/zcap/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1"
+  ],
+  "id": "urn:uuid:cdc77118-6bfa-11ec-aceb-10bf48838a41",
+  "parentCapability": "urn:zcap:root:https%3A%2F%2Fvcalm-instances.example.com%2Fissuers%2Fb77c9b57-c321-4d14-902c-8f442a37707d%2Fworkflows%2Fa6513552-8e5a-4efa-b36e-1fb2a8e06822%2Fexchanges",
+  "controller": "did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG",
+  "invocationTarget": "https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822/exchanges",
+  "expires": "2027-06-30T16:45:73Z",
+  "allowedAction": [
+    "write",
+    "read"
+  ],
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2026-06-30T16:45:73Z",
+    "verificationMethod": "did:key:z6MkfWKcvBiKCfNgz5UUGseNt37t4dguEvFgJ9XvX2UV6zB9#z6MkfWKcvBiKCfNgz5UUGseNt37t4dguEvFgJ9XvX2UV6zB9",
+    "proofPurpose": "capabilityDelegation",
+    "capabilityChain": [
+      "urn:zcap:root:https%3A%2F%2Fvcalm-instances.example.com%2Fissuers%2Fb77c9b57-c321-4d14-902c-8f442a37707d%2Fworkflows%2Fa6513552-8e5a-4efa-b36e-1fb2a8e06822%2Fexchanges"
+    ],
+    "proofValue": "z3t9BCQyF21MDVYmLKc9zbLreqx4wBtQnUsd5aqyoWS5FfhapRz7QjPNLcgKAornUVmJR4ZjbGpuxRFnffxX1ZjtF"
+  }
+}
+          </pre>
+          <p>
+The `read` action enables operations that do not create or update resources in
+the system to be performed on the provided path, or on any path containing the
+provided path as a prefix, as permitted by `invocationTarget` and `allowedAction`
+in the zcap. The `write` action enables operations that create and/or update
+resources in the system to be performed on the provided path, or on any path
+that contains the provided path as a prefix, as permitted by `invocationTarget`
+and `allowedAction` in the zcap. In order to enforce the principle of
+least privilege, implementers SHOULD apply the following best practices:
+          </p>
+          <ol>
+            <li>
+Ensure that zcaps identify a specific URL that references resources via the `invocationTarget` property
+and the client that is authorized to access those resources via the `controller` property.
+This enables the zcap to be pinned to a particular client and server (along with its resources).
+Example `invocationTarget` value: `https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822`.
+Example `controller` value: `did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG`.
+            </li>
+            <li>
+Refer to Section [[[#component-overview]]] to determine which `invocationTarget`
+and `allowedAction` values to include in zcaps distributed to clients,
+based on the HTTP method
+(e.g., `GET` -> `read`, `POST` -> `write`) and the expected caller
+of the API endpoint of interest.
+            </li>
+          </ol>
+          <p>
+Examples of valid delegated capability subsets are shown below:
+          </p>
+          <ul>
+            <li>
+              <h4>
+Allow a client controller to retrieve the configuration
+of a particular workflow instance
+(distribute zcaps with this subset to an administrator)
+              </h4>
+              <pre title="Retrieve Workflow Configuration">
+{
+  ...
+  "controller": "did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG",
+  "invocationTarget": "https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822",
+  "allowedAction": [
+    "read"
+  ],
+  ...
+}
+              </pre>
+            </li>
+            <li>
+              <h4>
+Allow a client controller to create an exchange
+on a particular workflow instance
+(distribute zcaps with this subset to a coordinator)
+              </h4>
+              <pre title="Create Exchange">
+{
+  ...
+  "controller": "did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG",
+  "invocationTarget": "https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822/exchanges",
+  "allowedAction": [
+    "write"
+  ],
+  ...
+}
+              </pre>
+            </li>
+            <li>
+              <h4>
+Allow a client controller to retrieve the state of an exchange
+originating from a particular workflow instance
+(distribute zcaps with this subset to a coordinator)
+              </h4>
+              <pre title="Retrieve Exchange State">
+{
+  ...
+  "controller": "did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG",
+  "invocationTarget": "https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822/exchanges",
+  "allowedAction": [
+    "read"
+  ],
+  ...
+}
+              </pre>
+            </li>
+            <li>
+              <h4>
+Allow a client controller to access the credential issuance API endpoint
+on the issuer instance identified in the zcap
+(distribute zcaps with this subset to an issuer coordinator or
+a workflow service)
+              </h4>
+              <pre title="Issue Credential">
+{
+  ...
+  "controller": "did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG",
+  "invocationTarget": "https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/credentials/issue",
+  "allowedAction": [
+    "write"
+  ],
+  ...
+}
+              </pre>
+            </li>
+          </ul>
         </section>
 
         <section class="notoc">

--- a/index.html
+++ b/index.html
@@ -867,7 +867,7 @@ a path within that domain (e.g., <code>website.example/api</code>).
           <p>
 If Authorization Capabilities (ZCAPs) are used for authorization,
 the administrator is expected to delegate a ZCAP with the appropriate
-format as defined in [[[?ZCAP]]] and as needed for the use case.
+format as defined in [[?ZCAP]] and as needed for the use case.
 This includes appropriate values for the controller, invocation target,
 and allowed actions, among other important properties.
           </p>

--- a/index.html
+++ b/index.html
@@ -865,8 +865,8 @@ a path within that domain (e.g., <code>website.example/api</code>).
         <section class="notoc">
           <h4>Authorization Capabilities</h4>
           <p>
-If Authorization Capabilities (zcaps) are used for authorization,
-the administrator SHOULD delegate a zcap with the appropriate
+If Authorization Capabilities (ZCAPs) are used for authorization,
+the administrator SHOULD delegate a ZCAP with the appropriate
 format as defined in [[[ZCAP]]] and as required for the use case.
 This includes appropriate values for the controller, invocation target,
 and allowed actions, among other important properties.
@@ -902,23 +902,23 @@ and allowed actions, among other important properties.
 The `read` action enables operations that do not create or update resources in
 the system to be performed on the provided path, or on any path containing the
 provided path as a prefix, as permitted by `invocationTarget` and `allowedAction`
-in the zcap. The `write` action enables operations that create and/or update
+in the ZCAP. The `write` action enables operations that create and/or update
 resources in the system to be performed on the provided path, or on any path
 that contains the provided path as a prefix, as permitted by `invocationTarget`
-and `allowedAction` in the zcap. In order to enforce the principle of
+and `allowedAction` in the ZCAP. In order to enforce the principle of
 least privilege, implementers SHOULD apply the following best practices:
           </p>
           <ol>
             <li>
-Ensure that zcaps identify a specific URL that references resources via the `invocationTarget` property
+Ensure that ZCAPs identify a specific URL that references resources via the `invocationTarget` property
 and the client that is authorized to access those resources via the `controller` property.
-This enables the zcap to be pinned to a particular client and server (along with its resources).
+This enables the ZCAP to be pinned to a particular client and server (along with its resources).
 Example `invocationTarget` value: `https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822`.
 Example `controller` value: `did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG`.
             </li>
             <li>
 Refer to Section [[[#component-overview]]] to determine which `invocationTarget`
-and `allowedAction` values to include in zcaps distributed to clients,
+and `allowedAction` values to include in ZCAPs distributed to clients,
 based on the HTTP method
 (e.g., `GET` -> `read`, `POST` -> `write`) and the expected caller
 of the API endpoint of interest.
@@ -932,7 +932,7 @@ Examples of valid delegated capability subsets are shown below:
               <h4>
 Allow a client controller to retrieve the configuration
 of a particular workflow instance
-(distribute zcaps with this subset to an administrator)
+(distribute ZCAPs with this subset to an administrator)
               </h4>
               <pre title="Retrieve Workflow Configuration">
 {
@@ -950,7 +950,7 @@ of a particular workflow instance
               <h4>
 Allow a client controller to create an exchange
 on a particular workflow instance
-(distribute zcaps with this subset to a coordinator)
+(distribute ZCAPs with this subset to a coordinator)
               </h4>
               <pre title="Create Exchange">
 {
@@ -968,7 +968,7 @@ on a particular workflow instance
               <h4>
 Allow a client controller to retrieve the state of an exchange
 originating from a particular workflow instance
-(distribute zcaps with this subset to a coordinator)
+(distribute ZCAPs with this subset to a coordinator)
               </h4>
               <pre title="Retrieve Exchange State">
 {
@@ -985,8 +985,8 @@ originating from a particular workflow instance
             <li>
               <h4>
 Allow a client controller to access the credential issuance API endpoint
-on the issuer instance identified in the zcap
-(distribute zcaps with this subset to an issuer coordinator or
+on the issuer instance identified in the ZCAP
+(distribute ZCAPs with this subset to an issuer coordinator or
 a workflow service)
               </h4>
               <pre title="Issue Credential">
@@ -1921,7 +1921,7 @@ queried.
 
         <p>
 This query type would be included in a request to ask for Authorization
-Capabilities or "zcaps" in the Verifiable Presentation.
+Capabilities or "ZCAPs" in the Verifiable Presentation.
         </p>
 
         <pre class="example nohighlight" title="An Authorization Capability Request query">

--- a/index.html
+++ b/index.html
@@ -867,7 +867,7 @@ a path within that domain (e.g., <code>website.example/api</code>).
           <p>
 If Authorization Capabilities (ZCAPs) are used for authorization,
 the administrator is expected to delegate a ZCAP with the appropriate
-format as defined in [[[ZCAP]]] and as required for the use case.
+format as defined in [[[?ZCAP]]] and as needed for the use case.
 This includes appropriate values for the controller, invocation target,
 and allowed actions, among other important properties.
           </p>

--- a/index.html
+++ b/index.html
@@ -880,7 +880,7 @@ and allowed actions, among other important properties.
   "id": "urn:uuid:cdc77118-6bfa-11ec-aceb-10bf48838a41",
   "parentCapability": "urn:zcap:root:https%3A%2F%2Fvcalm-instances.example.com%2Fissuers%2Fb77c9b57-c321-4d14-902c-8f442a37707d%2Fworkflows%2Fa6513552-8e5a-4efa-b36e-1fb2a8e06822%2Fexchanges",
   "controller": "did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG",
-  "invocationTarget": "https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822/exchanges",
+  "invocationTarget": "https://vcalm-instances.example.com/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822/exchanges",
   "expires": "2027-06-30T16:45:73Z",
   "allowedAction": [
     "write",
@@ -905,7 +905,7 @@ provided path as a prefix, as permitted by `invocationTarget` and `allowedAction
 in the ZCAP. The `write` action enables operations that create and/or update
 resources in the system to be performed on the provided path, or on any path
 that contains the provided path as a prefix, as permitted by `invocationTarget`
-and `allowedAction` in the ZCAP. In order to enforce the principle of
+and `allowedAction` in the ZCAP. To enforce the principle of
 least privilege, implementers are expected to apply the following best practices:
           </p>
           <ol>
@@ -913,7 +913,7 @@ least privilege, implementers are expected to apply the following best practices
 Ensure that ZCAPs identify a specific URL that references resources via the `invocationTarget` property
 and the client that is authorized to access those resources via the `controller` property.
 This enables the ZCAP to be pinned to a particular client and server (along with its resources).
-Example `invocationTarget` value: `https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822`.
+Example `invocationTarget` value: `https://vcalm-instances.example.com/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822`.
 Example `controller` value: `did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG`.
             </li>
             <li>
@@ -930,16 +930,17 @@ Examples of valid delegated capability subsets are shown below:
           <ul>
             <li>
               <h4>
-Allow a client controller to retrieve the configuration
+Allow a client controller to update or retrieve the configuration
 of a particular workflow instance
 (a ZCAP with this subset is expected to be distributed to an administrator)
               </h4>
-              <pre title="Retrieve Workflow Configuration">
+              <pre title="Update or Retrieve Workflow Configuration">
 {
   ...
   "controller": "did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG",
-  "invocationTarget": "https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822",
+  "invocationTarget": "https://vcalm-instances.example.com/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822",
   "allowedAction": [
+    "write",
     "read"
   ],
   ...
@@ -948,34 +949,17 @@ of a particular workflow instance
             </li>
             <li>
               <h4>
-Allow a client controller to create an exchange
-on a particular workflow instance
+Allow a client controller to create exchanges or retrieve the state of any exchange
+from a particular workflow instance
 (a ZCAP with this subset is expected to be distributed to a coordinator)
               </h4>
-              <pre title="Create Exchange">
+              <pre title="Create Exchange or Retrieve Exchange State">
 {
   ...
   "controller": "did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG",
-  "invocationTarget": "https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822/exchanges",
+  "invocationTarget": "https://vcalm-instances.example.com/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822/exchanges",
   "allowedAction": [
-    "write"
-  ],
-  ...
-}
-              </pre>
-            </li>
-            <li>
-              <h4>
-Allow a client controller to retrieve the state of an exchange
-originating from a particular workflow instance
-(a ZCAP with this subset is expected to be distributed to a coordinator)
-              </h4>
-              <pre title="Retrieve Exchange State">
-{
-  ...
-  "controller": "did:key:z6MknBxrctS4KsfiBsEaXsfnrnfNYTvDjVpLYYUAN6PX2EfG",
-  "invocationTarget": "https://vcalm-instances.example.com/issuers/b77c9b57-c321-4d14-902c-8f442a37707d/workflows/a6513552-8e5a-4efa-b36e-1fb2a8e06822/exchanges",
-  "allowedAction": [
+    "write",
     "read"
   ],
   ...

--- a/index.html
+++ b/index.html
@@ -866,7 +866,7 @@ a path within that domain (e.g., <code>website.example/api</code>).
           <h4>Authorization Capabilities</h4>
           <p>
 If Authorization Capabilities (ZCAPs) are used for authorization,
-the administrator SHOULD delegate a ZCAP with the appropriate
+the administrator is expected to delegate a ZCAP with the appropriate
 format as defined in [[[ZCAP]]] and as required for the use case.
 This includes appropriate values for the controller, invocation target,
 and allowed actions, among other important properties.
@@ -906,7 +906,7 @@ in the ZCAP. The `write` action enables operations that create and/or update
 resources in the system to be performed on the provided path, or on any path
 that contains the provided path as a prefix, as permitted by `invocationTarget`
 and `allowedAction` in the ZCAP. In order to enforce the principle of
-least privilege, implementers SHOULD apply the following best practices:
+least privilege, implementers are expected to apply the following best practices:
           </p>
           <ol>
             <li>
@@ -932,7 +932,7 @@ Examples of valid delegated capability subsets are shown below:
               <h4>
 Allow a client controller to retrieve the configuration
 of a particular workflow instance
-(distribute ZCAPs with this subset to an administrator)
+(a ZCAP with this subset is expected to be distributed to an administrator)
               </h4>
               <pre title="Retrieve Workflow Configuration">
 {
@@ -950,7 +950,7 @@ of a particular workflow instance
               <h4>
 Allow a client controller to create an exchange
 on a particular workflow instance
-(distribute ZCAPs with this subset to a coordinator)
+(a ZCAP with this subset is expected to be distributed to a coordinator)
               </h4>
               <pre title="Create Exchange">
 {
@@ -968,7 +968,7 @@ on a particular workflow instance
               <h4>
 Allow a client controller to retrieve the state of an exchange
 originating from a particular workflow instance
-(distribute ZCAPs with this subset to a coordinator)
+(a ZCAP with this subset is expected to be distributed to a coordinator)
               </h4>
               <pre title="Retrieve Exchange State">
 {
@@ -986,7 +986,7 @@ originating from a particular workflow instance
               <h4>
 Allow a client controller to access the credential issuance API endpoint
 on the issuer instance identified in the ZCAP
-(distribute ZCAPs with this subset to an issuer coordinator or
+(a ZCAP with this subset is expected to be distributed to an issuer coordinator or
 a workflow service)
               </h4>
               <pre title="Issue Credential">

--- a/index.html
+++ b/index.html
@@ -968,7 +968,7 @@ from a particular workflow instance
             </li>
             <li>
               <h4>
-Allow a client controller to access the credential issuance API endpoint
+Allow a client controller to access the API endpoint for credential issuance
 on the issuer instance identified in the ZCAP
 (a ZCAP with this subset is expected to be distributed to an issuer coordinator or
 a workflow service)


### PR DESCRIPTION
This PR addresses Issue #644 by defining valid set of ZCAP actions in the VCALM spec, and providing valid examples of delegated ZCAPs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 11, 2026, 10:34 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=respec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fvcalm%2F0c9107780845849348fec67af207505a229982b9%2Findex.html%3FisPreview%3Dtrue)

**Error output:**

```
EISDIR: illegal operation on a directory, open 'uploads/NYv3YI/'
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/vcalm%23657.)._

</details>
