### PR TITLE
Simplify credential and presentation OAS schemas

### DIFF
--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -18,28 +18,14 @@ components:
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the credential.
+          description: The JSON-LD context of the credential. Each item in the @context array MUST be a string.
           items:
             type: string
-        "id":
-          type: string
-          description: The ID of the credential. This property MAY be empty. The issuer SHOULD NOT auto-generate the id property if not provided, as a Verifiable Credential does not require the id property to be valid, and there are use cases for which the id property cannot be set.
         "type":
           type: array
-          description: The JSON-LD type of the credential.
+          description: The JSON-LD type of the credential. Each item in the type array MUST be a string.
           items:
             type: string
-        "issuer":
-          $ref: "./Issuer.yml#/components/schemas/Issuer"
-        "validFrom":
-          type: string
-          description: The validFrom date
-        "validUntil":
-          type: string
-          description: The validUntil date
-        "credentialSubject":
-          type: object
-          description: A REQUIRED property describing the subject of the credential.
       example:
         {
           "@context":
@@ -47,23 +33,11 @@ components:
               "https://www.w3.org/ns/credentials/v2",
               "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "id": "http://example.gov/credentials/3732",
           "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-          "issuer": "did:example:123",
-          "validFrom": "2020-03-16T22:37:26.544Z",
-          "credentialSubject":
-            {
-              "id": "did:example:123",
-              "degree":
-                {
-                  "type": "BachelorDegree",
-                  "name": "Bachelor of Science and Arts",
-                }
-            }
         }
     UnsecuredCredential:
       type: object
-      description: A verifiable credential intended for issuance. Additional properties conform to the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model-2.0/).
+      description: A W3C Verifiable Credential intended for issuance.
       properties:
         "@context":
           type: array

--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
-  version: "0.0.3-unstable"
-  title: VC API
-  description: This is an Experimental Open API Specification for the [VC Data Model](https://www.w3.org/TR/vc-data-model/).
+  version: "1.0.0"
+  title: Simple W3C Credential Schema
+  description: This specifies simplified W3C credential schemas sufficient for the purposes of VCALM.
   license:
     name: W3C Software and Document License
     url: http://www.w3.org/Consortium/Legal/copyright-software.
@@ -12,55 +12,28 @@ info:
 paths:
 components:
   schemas:
+    CredentialDocument:
+      type: object
+      description: A JSON-LD Verifiable Credential document.
+      properties:
+        "@context":
+          type: array
+          description: The JSON-LD context of the credential.
+          items:
+            type: string
+        "type":
+          type: array
+          description: The JSON-LD type of the credential.
+          items:
+            type: string
     Credential:
-      type: object
-      description: A JSON-LD Verifiable Credential without a proof.
-      properties:
-        "@context":
-          type: array
-          description: The JSON-LD context of the credential.
-          items:
-            type: string
-        "type":
-          type: array
-          description: The JSON-LD type of the credential.
-          items:
-            type: string
-      example:
-        {
-          "@context":
-            [
-              "https://www.w3.org/ns/credentials/v2",
-              "https://www.w3.org/ns/credentials/examples/v2",
-            ],
-          "id": "http://example.gov/credentials/3732",
-          "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-          "issuer": "did:example:123",
-          "validFrom": "2020-03-16T22:37:26.544Z",
-          "credentialSubject":
-            {
-              "id": "did:example:123",
-              "degree":
-                {
-                  "type": "BachelorDegree",
-                  "name": "Bachelor of Science and Arts",
-                }
-            }
-        }
-    UnsecuredCredential:
-      type: object
-      description: A W3C Verifiable Credential intended for issuance.
-      properties:
-        "@context":
-          type: array
-          description: The JSON-LD context of the credential.
-          items:
-            type: string
-        "type":
-          type: array
-          description: The JSON-LD type of the credential.
-          items:
-            type: string
+      description: >
+        A JSON-LD credential document used where the API expects an input
+        credential to be issued or processed, such as in
+        IssueCredentialRequest.credential. The document MAY include an
+        embedded proof.
+      allOf:
+        - $ref: "#/components/schemas/CredentialDocument"
       example:
         {
           "@context":

--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -14,18 +14,32 @@ components:
   schemas:
     Credential:
       type: object
-      description: A verifiable credential without a proof. Additional properties conform to the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model-2.0/).
+      description: A JSON-LD Verifiable Credential without a proof.
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the credential. Each item in the @context array MUST be a string.
+          description: The JSON-LD context of the credential.
           items:
             type: string
+        "id":
+          type: string
+          description: The ID of the credential. This property MAY be empty. The issuer SHOULD NOT auto-generate the id property if not provided, as a Verifiable Credential does not require the id property to be valid, and there are use cases for which the id property cannot be set.
         "type":
           type: array
-          description: The JSON-LD type of the credential. Each item in the type array MUST be a string.
+          description: The JSON-LD type of the credential.
           items:
             type: string
+        "issuer":
+          $ref: "./Issuer.yml#/components/schemas/Issuer"
+        "validFrom":
+          type: string
+          description: The validFrom date
+        "validUntil":
+          type: string
+          description: The validUntil date
+        "credentialSubject":
+          type: object
+          description: A REQUIRED property describing the subject of the credential.
       example:
         {
           "@context":
@@ -33,7 +47,19 @@ components:
               "https://www.w3.org/ns/credentials/v2",
               "https://www.w3.org/ns/credentials/examples/v2",
             ],
+          "id": "http://example.gov/credentials/3732",
           "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+          "issuer": "did:example:123",
+          "validFrom": "2020-03-16T22:37:26.544Z",
+          "credentialSubject":
+            {
+              "id": "did:example:123",
+              "degree":
+                {
+                  "type": "BachelorDegree",
+                  "name": "Bachelor of Science and Arts",
+                }
+            }
         }
     UnsecuredCredential:
       type: object

--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -14,32 +14,18 @@ components:
   schemas:
     Credential:
       type: object
-      description: A JSON-LD Verifiable Credential without a proof.
+      description: A verifiable credential without a proof. Additional properties conform to the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model-2.0/).
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the credential.
+          description: The JSON-LD context of the credential. Each item in the @context array MUST be a string.
           items:
             type: string
-        "id":
-          type: string
-          description: The ID of the credential. This property MAY be empty. The issuer SHOULD NOT auto-generate the id property if not provided, as a Verifiable Credential does not require the id property to be valid, and there are use cases for which the id property cannot be set.
         "type":
           type: array
-          description: The JSON-LD type of the credential.
+          description: The JSON-LD type of the credential. Each item in the type array MUST be a string.
           items:
             type: string
-        "issuer":
-          $ref: "./Issuer.yml#/components/schemas/Issuer"
-        "validFrom":
-          type: string
-          description: The validFrom date
-        "validUntil":
-          type: string
-          description: The validUntil date
-        "credentialSubject":
-          type: object
-          description: A REQUIRED property describing the subject of the credential.
       example:
         {
           "@context":
@@ -47,59 +33,22 @@ components:
               "https://www.w3.org/ns/credentials/v2",
               "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "id": "http://example.gov/credentials/3732",
           "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-          "issuer": "did:example:123",
-          "validFrom": "2020-03-16T22:37:26.544Z",
-          "credentialSubject":
-            {
-              "id": "did:example:123",
-              "degree":
-                {
-                  "type": "BachelorDegree",
-                  "name": "Bachelor of Science and Arts",
-                }
-            }
         }
     UnsecuredCredential:
       type: object
-      description: A W3C Verifiable Credential intended for issuance.
+      description: A verifiable credential intended for issuance. Additional properties conform to the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model-2.0/).
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the credential.
+          description: The JSON-LD context of the credential. Each item in the @context array MUST be a string.
           items:
             type: string
-        "id":
-          type: string
-          description: The ID of the credential.
         "type":
           type: array
-          description: The JSON-LD type of the credential.
+          description: The JSON-LD type of the credential. Each item in the type array MUST be a string.
           items:
             type: string
-        "issuer":
-          $ref: "./Issuer.yml#/components/schemas/IssuerRequest"
-        "validFrom":
-          type: string
-          description: The validFrom date
-        "validUntil":
-          type: string
-          description: The validUntil date
-        "credentialSubject":
-          type: object
-          description: A REQUIRED property describing the subject of the credential.
-        "proof":
-          type: object
-          description: >
-            An optional proof or array of proofs for credentials that are secured using proof sets or chains.
-            When present, the configuration of the issuer instance determines how these existing proofs are
-            processed (e.g., append to create proof sets/chains, or trigger an error).
-          oneOf:
-            - type: object
-            - type: array
-              items:
-                type: object
       example:
         {
           "@context":
@@ -107,17 +56,5 @@ components:
               "https://www.w3.org/ns/credentials/v2",
               "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "id": "http://example.gov/credentials/3732",
           "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-          "issuer": "did:example:123",
-          "validFrom": "2020-03-16T22:37:26.544Z",
-          "credentialSubject":
-            {
-              "id": "did:example:123",
-              "degree":
-                {
-                  "type": "BachelorDegree",
-                  "name": "Bachelor of Science and Arts",
-                }
-            }
         }

--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -18,12 +18,12 @@ components:
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the credential. Each item in the @context array MUST be a string.
+          description: The JSON-LD context of the credential.
           items:
             type: string
         "type":
           type: array
-          description: The JSON-LD type of the credential. Each item in the type array MUST be a string.
+          description: The JSON-LD type of the credential.
           items:
             type: string
       example:
@@ -41,12 +41,12 @@ components:
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the credential. Each item in the @context array MUST be a string.
+          description: The JSON-LD context of the credential.
           items:
             type: string
         "type":
           type: array
-          description: The JSON-LD type of the credential. Each item in the type array MUST be a string.
+          description: The JSON-LD type of the credential.
           items:
             type: string
       example:

--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -33,7 +33,19 @@ components:
               "https://www.w3.org/ns/credentials/v2",
               "https://www.w3.org/ns/credentials/examples/v2",
             ],
+          "id": "http://example.gov/credentials/3732",
           "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+          "issuer": "did:example:123",
+          "validFrom": "2020-03-16T22:37:26.544Z",
+          "credentialSubject":
+            {
+              "id": "did:example:123",
+              "degree":
+                {
+                  "type": "BachelorDegree",
+                  "name": "Bachelor of Science and Arts",
+                }
+            }
         }
     UnsecuredCredential:
       type: object
@@ -56,5 +68,17 @@ components:
               "https://www.w3.org/ns/credentials/v2",
               "https://www.w3.org/ns/credentials/examples/v2",
             ],
+          "id": "http://example.gov/credentials/3732",
           "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+          "issuer": "did:example:123",
+          "validFrom": "2020-03-16T22:37:26.544Z",
+          "credentialSubject":
+            {
+              "id": "did:example:123",
+              "degree":
+                {
+                  "type": "BachelorDegree",
+                  "name": "Bachelor of Science and Arts",
+                }
+            }
         }

--- a/components/Presentation.yml
+++ b/components/Presentation.yml
@@ -18,12 +18,12 @@ components:
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the presentation. Each item in the @context array MUST be a string.
+          description: The JSON-LD context of the presentation.
           items:
             type: string
         "type":
           type: array
-          description: The JSON-LD type of the presentation. Each item in the type array MUST be a string.
+          description: The JSON-LD type of the presentation.
           items:
             type: string
       example:

--- a/components/Presentation.yml
+++ b/components/Presentation.yml
@@ -14,24 +14,67 @@ components:
   schemas:
     Presentation:
       type: object
-      description: A verifiable presentation without a proof. Additional properties conform to the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model-2.0/).
+      description: A JSON-LD Verifiable Presentation without a proof.
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the presentation. Each item in the @context array MUST be a string.
+          description: The JSON-LD context of the presentation.
           items:
             type: string
+        "id":
+          type: string
+          description: The ID of the presentation.
         "type":
           type: array
-          description: The JSON-LD type of the presentation. Each item in the type array MUST be a string.
+          description: The JSON-LD type of the presentation.
           items:
             type: string
+        "holder":
+          type: object
+          description: The holder - will be ignored if no proof is present since there is no proof of authority over the credentials
+          nullable: true
+        "verifiableCredential":
+          type: array
+          description: The Verifiable Credentials
+          items:
+            $ref: "./VerifiableCredential.yml#/components/schemas/VerifiableCredential"
       example:
         {
           "@context":
             [
-              "https://www.w3.org/ns/credentials/v2",
-              "https://www.w3.org/ns/credentials/examples/v2",
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "type": ["VerifiablePresentation"],
+          "holder": "did:example:123",
+          "type": "VerifiablePresentation",
+          "verifiableCredential":
+            [
+                "@context":
+                  [
+                      "https://www.w3.org/ns/credentials/v2",
+                      "https://www.w3.org/ns/credentials/examples/v2",
+                  ],
+                "id": "http://example.gov/credentials/3732",
+                "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+                "issuer": "did:example:123",
+                "validFrom": "2020-03-16T22:37:26.544Z",
+                "credentialSubject":
+                  {
+                    "id": "did:example:123",
+                    "degree":
+                      {
+                        "type": "BachelorDegree",
+                        "name": "Bachelor of Science and Arts",
+                      },
+                  },
+                "proof":
+                  {
+                    "type": "DataIntegrityProof",
+                    "cryptosuite": "ecdsa-rdfc-2019",
+                    "created": "2020-04-02T18:28:08Z",
+                    "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+                    "proofPurpose": "assertionMethod",
+                    "proofValue": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
+                  },
+            ],
         }

--- a/components/Presentation.yml
+++ b/components/Presentation.yml
@@ -18,63 +18,20 @@ components:
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the presentation.
+          description: The JSON-LD context of the presentation. Each item in the @context array MUST be a string.
           items:
             type: string
-        "id":
-          type: string
-          description: The ID of the presentation.
         "type":
           type: array
-          description: The JSON-LD type of the presentation.
+          description: The JSON-LD type of the presentation. Each item in the type array MUST be a string.
           items:
             type: string
-        "holder":
-          type: object
-          description: The holder - will be ignored if no proof is present since there is no proof of authority over the credentials
-          nullable: true
-        "verifiableCredential":
-          type: array
-          description: The Verifiable Credentials
-          items:
-            $ref: "./VerifiableCredential.yml#/components/schemas/VerifiableCredential"
       example:
         {
           "@context":
             [
-                "https://www.w3.org/ns/credentials/v2",
-                "https://www.w3.org/ns/credentials/examples/v2",
+              "https://www.w3.org/ns/credentials/v2",
+              "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "holder": "did:example:123",
-          "type": "VerifiablePresentation",
-          "verifiableCredential":
-            [
-                "@context":
-                  [
-                      "https://www.w3.org/ns/credentials/v2",
-                      "https://www.w3.org/ns/credentials/examples/v2",
-                  ],
-                "id": "http://example.gov/credentials/3732",
-                "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-                "issuer": "did:example:123",
-                "validFrom": "2020-03-16T22:37:26.544Z",
-                "credentialSubject":
-                  {
-                    "id": "did:example:123",
-                    "degree":
-                      {
-                        "type": "BachelorDegree",
-                        "name": "Bachelor of Science and Arts",
-                      },
-                  },
-                "proof":
-                  {
-                    "type": "DataIntegrityProof",
-                    "cryptosuite": "ecdsa-rdfc-2019",
-                    "created": "2020-04-02T18:28:08Z",
-                    "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
-                    "proofPurpose": "assertionMethod",
-                    "proofValue": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
-                  },
-            ],
+          "type": ["VerifiablePresentation"],
         }

--- a/components/Presentation.yml
+++ b/components/Presentation.yml
@@ -30,8 +30,39 @@ components:
         {
           "@context":
             [
-              "https://www.w3.org/ns/credentials/v2",
-              "https://www.w3.org/ns/credentials/examples/v2",
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "type": ["VerifiablePresentation"],
+          "holder": "did:example:123",
+          "type": "VerifiablePresentation",
+          "verifiableCredential":
+            [
+                "@context":
+                  [
+                      "https://www.w3.org/ns/credentials/v2",
+                      "https://www.w3.org/ns/credentials/examples/v2",
+                  ],
+                "id": "http://example.gov/credentials/3732",
+                "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+                "issuer": "did:example:123",
+                "validFrom": "2020-03-16T22:37:26.544Z",
+                "credentialSubject":
+                  {
+                    "id": "did:example:123",
+                    "degree":
+                      {
+                        "type": "BachelorDegree",
+                        "name": "Bachelor of Science and Arts",
+                      },
+                  },
+                "proof":
+                  {
+                    "type": "DataIntegrityProof",
+                    "cryptosuite": "ecdsa-rdfc-2019",
+                    "created": "2020-04-02T18:28:08Z",
+                    "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+                    "proofPurpose": "assertionMethod",
+                    "proofValue": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
+                  },
+            ],
         }

--- a/components/Presentation.yml
+++ b/components/Presentation.yml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
-  version: "0.0.3-unstable"
-  title: VC API
-  description: This is an Experimental Open API Specification for the [VC Data Model](https://www.w3.org/TR/vc-data-model/).
+  version: "1.0.0"
+  title: Simple W3C Presentation Schema
+  description: This specifies a simplified W3C presentation schema sufficient for the purposes of VCALM.
   license:
     name: W3C Software and Document License
     url: http://www.w3.org/Consortium/Legal/copyright-software.
@@ -12,9 +12,9 @@ info:
 paths:
 components:
   schemas:
-    Presentation:
+    PresentationDocument:
       type: object
-      description: A JSON-LD Verifiable Presentation without a proof.
+      description: A JSON-LD Verifiable Presentation document.
       properties:
         "@context":
           type: array
@@ -26,6 +26,14 @@ components:
           description: The JSON-LD type of the presentation.
           items:
             type: string
+    Presentation:
+      description: >
+        A JSON-LD presentation document used where the API expects an input
+        presentation to be created or processed, such as in
+        CreatePresentationRequest.presentation. The document MAY include an
+        embedded proof.
+      allOf:
+        - $ref: "#/components/schemas/PresentationDocument"
       example:
         {
           "@context":

--- a/components/Presentation.yml
+++ b/components/Presentation.yml
@@ -14,67 +14,24 @@ components:
   schemas:
     Presentation:
       type: object
-      description: A JSON-LD Verifiable Presentation without a proof.
+      description: A verifiable presentation without a proof. Additional properties conform to the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model-2.0/).
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the presentation.
+          description: The JSON-LD context of the presentation. Each item in the @context array MUST be a string.
           items:
             type: string
-        "id":
-          type: string
-          description: The ID of the presentation.
         "type":
           type: array
-          description: The JSON-LD type of the presentation.
+          description: The JSON-LD type of the presentation. Each item in the type array MUST be a string.
           items:
             type: string
-        "holder":
-          type: object
-          description: The holder - will be ignored if no proof is present since there is no proof of authority over the credentials
-          nullable: true
-        "verifiableCredential":
-          type: array
-          description: The Verifiable Credentials
-          items:
-            $ref: "./VerifiableCredential.yml#/components/schemas/VerifiableCredential"
       example:
         {
           "@context":
             [
-                "https://www.w3.org/ns/credentials/v2",
-                "https://www.w3.org/ns/credentials/examples/v2",
+              "https://www.w3.org/ns/credentials/v2",
+              "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "holder": "did:example:123",
-          "type": "VerifiablePresentation",
-          "verifiableCredential":
-            [
-                "@context":
-                  [
-                      "https://www.w3.org/ns/credentials/v2",
-                      "https://www.w3.org/ns/credentials/examples/v2",
-                  ],
-                "id": "http://example.gov/credentials/3732",
-                "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-                "issuer": "did:example:123",
-                "validFrom": "2020-03-16T22:37:26.544Z",
-                "credentialSubject":
-                  {
-                    "id": "did:example:123",
-                    "degree":
-                      {
-                        "type": "BachelorDegree",
-                        "name": "Bachelor of Science and Arts",
-                      },
-                  },
-                "proof":
-                  {
-                    "type": "DataIntegrityProof",
-                    "cryptosuite": "ecdsa-rdfc-2019",
-                    "created": "2020-04-02T18:28:08Z",
-                    "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
-                    "proofPurpose": "assertionMethod",
-                    "proofValue": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YtqjEYnFENT7fNW-COD0HAACxeuQxPKAmp4nIl8jYAu__6IH2FpSxv81w-l5PvE1og50tS9tH8WyXMlXyo45CA",
-                  },
-            ],
+          "type": ["VerifiablePresentation"],
         }

--- a/components/VerifiableCredential.yml
+++ b/components/VerifiableCredential.yml
@@ -14,40 +14,24 @@ components:
   schemas:
     VerifiableCredential:
       type: object
-      description: A JSON-LD Verifiable Credential with a proof.
-      allOf:
-        - $ref: "./Credential.yml#/components/schemas/Credential"
-        - type: object
-          properties:
-            proof:
-              $ref: "./DataIntegrityProof.yml#/components/schemas/DataIntegrityProof"
+      description: A verifiable credential. Additional properties conform to the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model-2.0/).
+      properties:
+        "@context":
+          type: array
+          description: The JSON-LD context of the credential. Each item in the @context array MUST be a string.
+          items:
+            type: string
+        "type":
+          type: array
+          description: The JSON-LD type of the credential. Each item in the type array MUST be a string.
+          items:
+            type: string
       example:
         {
           "@context":
             [
-                "https://www.w3.org/ns/credentials/v2",
-                "https://www.w3.org/ns/credentials/examples/v2",
+              "https://www.w3.org/ns/credentials/v2",
+              "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "id": "http://example.gov/credentials/3732",
           "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-          "issuer": "did:example:123",
-          "validFrom": "2020-03-16T22:37:26.544Z",
-          "credentialSubject":
-            {
-              "id": "did:example:123",
-              "degree":
-                {
-                  "type": "BachelorDegree",
-                  "name": "Bachelor of Science and Arts",
-                },
-            },
-          "proof":
-            {
-              "type": "DataIntegrityProof",
-              "cryptosuite": "ecdsa-rdfc-2019",
-              "created": "2020-04-02T18:28:08Z",
-              "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
-              "proofPurpose": "assertionMethod",
-              "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
-            },
         }

--- a/components/VerifiableCredential.yml
+++ b/components/VerifiableCredential.yml
@@ -18,12 +18,12 @@ components:
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the credential. Each item in the @context array MUST be a string.
+          description: The JSON-LD context of the credential.
           items:
             type: string
         "type":
           type: array
-          description: The JSON-LD type of the credential. Each item in the type array MUST be a string.
+          description: The JSON-LD type of the credential.
           items:
             type: string
       example:

--- a/components/VerifiableCredential.yml
+++ b/components/VerifiableCredential.yml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
-  version: "0.0.3-unstable"
-  title: VC API
-  description: This is an Experimental Open API Specification for the [VC Data Model](https://www.w3.org/TR/vc-data-model/).
+  version: "1.0.0"
+  title: Simple W3C Verifiable Credential Schema
+  description: This specifies a simplified W3C verifiable credential schema sufficient for the purposes of VCALM.
   license:
     name: W3C Software and Document License
     url: http://www.w3.org/Consortium/Legal/copyright-software.
@@ -13,19 +13,14 @@ paths:
 components:
   schemas:
     VerifiableCredential:
-      type: object
-      description: A JSON-LD Verifiable Credential with a proof.
-      properties:
-        "@context":
-          type: array
-          description: The JSON-LD context of the credential.
-          items:
-            type: string
-        "type":
-          type: array
-          description: The JSON-LD type of the credential.
-          items:
-            type: string
+      description: >
+        A JSON-LD credential document used where the API expects a secured
+        verifiable credential, such as in verify or derive operations and in
+        verifiableCredential response envelopes. The document MAY include an
+        embedded proof. An EnvelopedVerifiableCredential MAY be used instead
+        where noted in the API description.
+      allOf:
+        - $ref: "./Credential.yml#/components/schemas/CredentialDocument"
       example:
         {
           "@context":

--- a/components/VerifiableCredential.yml
+++ b/components/VerifiableCredential.yml
@@ -15,9 +15,9 @@ components:
     VerifiableCredential:
       description: >
         A JSON-LD credential document used where the API expects a secured
-        verifiable credential, such as in verify or derive operations and in
+        verifiable credential, such as in verify or derive operations, or in
         verifiableCredential response envelopes. The document MAY include an
-        embedded proof. An EnvelopedVerifiableCredential MAY be used instead
+        embedded proof. An EnvelopedVerifiableCredential MAY be used instead,
         where noted in the API description.
       allOf:
         - $ref: "./Credential.yml#/components/schemas/CredentialDocument"

--- a/components/VerifiableCredential.yml
+++ b/components/VerifiableCredential.yml
@@ -30,8 +30,29 @@ components:
         {
           "@context":
             [
-              "https://www.w3.org/ns/credentials/v2",
-              "https://www.w3.org/ns/credentials/examples/v2",
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2",
             ],
+          "id": "http://example.gov/credentials/3732",
           "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+          "issuer": "did:example:123",
+          "validFrom": "2020-03-16T22:37:26.544Z",
+          "credentialSubject":
+            {
+              "id": "did:example:123",
+              "degree":
+                {
+                  "type": "BachelorDegree",
+                  "name": "Bachelor of Science and Arts",
+                },
+            },
+          "proof":
+            {
+              "type": "DataIntegrityProof",
+              "cryptosuite": "ecdsa-rdfc-2019",
+              "created": "2020-04-02T18:28:08Z",
+              "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
+            },
         }

--- a/components/VerifiableCredential.yml
+++ b/components/VerifiableCredential.yml
@@ -15,39 +15,23 @@ components:
     VerifiableCredential:
       type: object
       description: A JSON-LD Verifiable Credential with a proof.
-      allOf:
-        - $ref: "./Credential.yml#/components/schemas/Credential"
-        - type: object
-          properties:
-            proof:
-              $ref: "./DataIntegrityProof.yml#/components/schemas/DataIntegrityProof"
+      properties:
+        "@context":
+          type: array
+          description: The JSON-LD context of the credential. Each item in the @context array MUST be a string.
+          items:
+            type: string
+        "type":
+          type: array
+          description: The JSON-LD type of the credential. Each item in the type array MUST be a string.
+          items:
+            type: string
       example:
         {
           "@context":
             [
-                "https://www.w3.org/ns/credentials/v2",
-                "https://www.w3.org/ns/credentials/examples/v2",
+              "https://www.w3.org/ns/credentials/v2",
+              "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "id": "http://example.gov/credentials/3732",
           "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-          "issuer": "did:example:123",
-          "validFrom": "2020-03-16T22:37:26.544Z",
-          "credentialSubject":
-            {
-              "id": "did:example:123",
-              "degree":
-                {
-                  "type": "BachelorDegree",
-                  "name": "Bachelor of Science and Arts",
-                },
-            },
-          "proof":
-            {
-              "type": "DataIntegrityProof",
-              "cryptosuite": "ecdsa-rdfc-2019",
-              "created": "2020-04-02T18:28:08Z",
-              "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
-              "proofPurpose": "assertionMethod",
-              "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
-            },
         }

--- a/components/VerifiableCredential.yml
+++ b/components/VerifiableCredential.yml
@@ -14,24 +14,40 @@ components:
   schemas:
     VerifiableCredential:
       type: object
-      description: A verifiable credential. Additional properties conform to the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model-2.0/).
-      properties:
-        "@context":
-          type: array
-          description: The JSON-LD context of the credential. Each item in the @context array MUST be a string.
-          items:
-            type: string
-        "type":
-          type: array
-          description: The JSON-LD type of the credential. Each item in the type array MUST be a string.
-          items:
-            type: string
+      description: A JSON-LD Verifiable Credential with a proof.
+      allOf:
+        - $ref: "./Credential.yml#/components/schemas/Credential"
+        - type: object
+          properties:
+            proof:
+              $ref: "./DataIntegrityProof.yml#/components/schemas/DataIntegrityProof"
       example:
         {
           "@context":
             [
-              "https://www.w3.org/ns/credentials/v2",
-              "https://www.w3.org/ns/credentials/examples/v2",
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2",
             ],
+          "id": "http://example.gov/credentials/3732",
           "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+          "issuer": "did:example:123",
+          "validFrom": "2020-03-16T22:37:26.544Z",
+          "credentialSubject":
+            {
+              "id": "did:example:123",
+              "degree":
+                {
+                  "type": "BachelorDegree",
+                  "name": "Bachelor of Science and Arts",
+                },
+            },
+          "proof":
+            {
+              "type": "DataIntegrityProof",
+              "cryptosuite": "ecdsa-rdfc-2019",
+              "created": "2020-04-02T18:28:08Z",
+              "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
+            },
         }

--- a/components/VerifiablePresentation.yml
+++ b/components/VerifiablePresentation.yml
@@ -15,58 +15,23 @@ components:
     VerifiablePresentation:
       type: object
       description: A JSON-LD Verifiable Presentation with a proof.
-      allOf:
-        - $ref: "./Presentation.yml#/components/schemas/Presentation"
-        - type: object
-          properties:
-            proof:
-              $ref: "./DataIntegrityProofWithChallenge.yml#/components/schemas/DataIntegrityProofWithChallenge"
+      properties:
+        "@context":
+          type: array
+          description: The JSON-LD context of the presentation. Each item in the @context array MUST be a string.
+          items:
+            type: string
+        "type":
+          type: array
+          description: The JSON-LD type of the presentation. Each item in the type array MUST be a string.
+          items:
+            type: string
       example:
         {
           "@context":
             [
-                "https://www.w3.org/ns/credentials/v2",
-                "https://www.w3.org/ns/credentials/examples/v2",
+              "https://www.w3.org/ns/credentials/v2",
+              "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "holder": "did:example:123",
-          "type": "VerifiablePresentation",
-          "verifiableCredential":
-            [
-                "@context":
-                  [
-                      "https://www.w3.org/ns/credentials/v2",
-                      "https://www.w3.org/ns/credentials/examples/v2",
-                  ],
-                "id": "http://example.gov/credentials/3732",
-                "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-                "issuer": "did:example:123",
-                "validFrom": "2020-03-16T22:37:26.544Z",
-                "credentialSubject":
-                  {
-                    "id": "did:example:123",
-                    "degree":
-                      {
-                        "type": "BachelorDegree",
-                        "name": "Bachelor of Science and Arts",
-                      },
-                  },
-                "proof":
-                  {
-                    "type": "DataIntegrityProof",
-                    "cryptosuite": "eddsa-rdfc-2022",
-                    "created": "2020-04-02T18:28:08Z",
-                    "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
-                    "proofPurpose": "assertionMethod",
-                    "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
-                  },
-            ],
-          "proof":
-            {
-              "type": "DataIntegrityProof",
-              "cryptosuite": "ecdsa-rdfc-2019",
-              "created": "2020-04-02T18:28:08Z",
-              "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
-              "proofPurpose": "assertionMethod",
-              "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
-            },
+          "type": ["VerifiablePresentation"],
         }

--- a/components/VerifiablePresentation.yml
+++ b/components/VerifiablePresentation.yml
@@ -18,12 +18,12 @@ components:
       properties:
         "@context":
           type: array
-          description: The JSON-LD context of the presentation. Each item in the @context array MUST be a string.
+          description: The JSON-LD context of the presentation.
           items:
             type: string
         "type":
           type: array
-          description: The JSON-LD type of the presentation. Each item in the type array MUST be a string.
+          description: The JSON-LD type of the presentation.
           items:
             type: string
       example:

--- a/components/VerifiablePresentation.yml
+++ b/components/VerifiablePresentation.yml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
-  version: "0.0.3-unstable"
-  title: VC API
-  description: This is an Experimental Open API Specification for the [VC Data Model](https://www.w3.org/TR/vc-data-model/).
+  version: "1.0.0"
+  title: Simple W3C Verifiable Presentation Schema
+  description: This specifies a simplified W3C verifiable presentation schema sufficient for the purposes of VCALM.
   license:
     name: W3C Software and Document License
     url: http://www.w3.org/Consortium/Legal/copyright-software.
@@ -13,19 +13,14 @@ paths:
 components:
   schemas:
     VerifiablePresentation:
-      type: object
-      description: A JSON-LD Verifiable Presentation with a proof.
-      properties:
-        "@context":
-          type: array
-          description: The JSON-LD context of the presentation.
-          items:
-            type: string
-        "type":
-          type: array
-          description: The JSON-LD type of the presentation.
-          items:
-            type: string
+      description: >
+        A JSON-LD presentation document used where the API expects a secured
+        verifiable presentation, such as in verify operations and in
+        verifiablePresentation response envelopes. The document MAY include an
+        embedded proof. An EnvelopedVerifiablePresentation MAY be used instead
+        where noted in the API description.
+      allOf:
+        - $ref: "./Presentation.yml#/components/schemas/PresentationDocument"
       example:
         {
           "@context":

--- a/components/VerifiablePresentation.yml
+++ b/components/VerifiablePresentation.yml
@@ -14,59 +14,24 @@ components:
   schemas:
     VerifiablePresentation:
       type: object
-      description: A JSON-LD Verifiable Presentation with a proof.
-      allOf:
-        - $ref: "./Presentation.yml#/components/schemas/Presentation"
-        - type: object
-          properties:
-            proof:
-              $ref: "./DataIntegrityProofWithChallenge.yml#/components/schemas/DataIntegrityProofWithChallenge"
+      description: A verifiable presentation. Additional properties conform to the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model-2.0/).
+      properties:
+        "@context":
+          type: array
+          description: The JSON-LD context of the presentation. Each item in the @context array MUST be a string.
+          items:
+            type: string
+        "type":
+          type: array
+          description: The JSON-LD type of the presentation. Each item in the type array MUST be a string.
+          items:
+            type: string
       example:
         {
           "@context":
             [
-                "https://www.w3.org/ns/credentials/v2",
-                "https://www.w3.org/ns/credentials/examples/v2",
+              "https://www.w3.org/ns/credentials/v2",
+              "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "holder": "did:example:123",
-          "type": "VerifiablePresentation",
-          "verifiableCredential":
-            [
-                "@context":
-                  [
-                      "https://www.w3.org/ns/credentials/v2",
-                      "https://www.w3.org/ns/credentials/examples/v2",
-                  ],
-                "id": "http://example.gov/credentials/3732",
-                "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-                "issuer": "did:example:123",
-                "validFrom": "2020-03-16T22:37:26.544Z",
-                "credentialSubject":
-                  {
-                    "id": "did:example:123",
-                    "degree":
-                      {
-                        "type": "BachelorDegree",
-                        "name": "Bachelor of Science and Arts",
-                      },
-                  },
-                "proof":
-                  {
-                    "type": "DataIntegrityProof",
-                    "cryptosuite": "eddsa-rdfc-2022",
-                    "created": "2020-04-02T18:28:08Z",
-                    "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
-                    "proofPurpose": "assertionMethod",
-                    "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
-                  },
-            ],
-          "proof":
-            {
-              "type": "DataIntegrityProof",
-              "cryptosuite": "ecdsa-rdfc-2019",
-              "created": "2020-04-02T18:28:08Z",
-              "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
-              "proofPurpose": "assertionMethod",
-              "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
-            },
+          "type": ["VerifiablePresentation"],
         }

--- a/components/VerifiablePresentation.yml
+++ b/components/VerifiablePresentation.yml
@@ -14,24 +14,59 @@ components:
   schemas:
     VerifiablePresentation:
       type: object
-      description: A verifiable presentation. Additional properties conform to the [Verifiable Credentials Data Model](https://www.w3.org/TR/vc-data-model-2.0/).
-      properties:
-        "@context":
-          type: array
-          description: The JSON-LD context of the presentation. Each item in the @context array MUST be a string.
-          items:
-            type: string
-        "type":
-          type: array
-          description: The JSON-LD type of the presentation. Each item in the type array MUST be a string.
-          items:
-            type: string
+      description: A JSON-LD Verifiable Presentation with a proof.
+      allOf:
+        - $ref: "./Presentation.yml#/components/schemas/Presentation"
+        - type: object
+          properties:
+            proof:
+              $ref: "./DataIntegrityProofWithChallenge.yml#/components/schemas/DataIntegrityProofWithChallenge"
       example:
         {
           "@context":
             [
-              "https://www.w3.org/ns/credentials/v2",
-              "https://www.w3.org/ns/credentials/examples/v2",
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "type": ["VerifiablePresentation"],
+          "holder": "did:example:123",
+          "type": "VerifiablePresentation",
+          "verifiableCredential":
+            [
+                "@context":
+                  [
+                      "https://www.w3.org/ns/credentials/v2",
+                      "https://www.w3.org/ns/credentials/examples/v2",
+                  ],
+                "id": "http://example.gov/credentials/3732",
+                "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+                "issuer": "did:example:123",
+                "validFrom": "2020-03-16T22:37:26.544Z",
+                "credentialSubject":
+                  {
+                    "id": "did:example:123",
+                    "degree":
+                      {
+                        "type": "BachelorDegree",
+                        "name": "Bachelor of Science and Arts",
+                      },
+                  },
+                "proof":
+                  {
+                    "type": "DataIntegrityProof",
+                    "cryptosuite": "eddsa-rdfc-2022",
+                    "created": "2020-04-02T18:28:08Z",
+                    "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+                    "proofPurpose": "assertionMethod",
+                    "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
+                  },
+            ],
+          "proof":
+            {
+              "type": "DataIntegrityProof",
+              "cryptosuite": "ecdsa-rdfc-2019",
+              "created": "2020-04-02T18:28:08Z",
+              "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
+            },
         }

--- a/components/VerifiablePresentation.yml
+++ b/components/VerifiablePresentation.yml
@@ -15,9 +15,9 @@ components:
     VerifiablePresentation:
       description: >
         A JSON-LD presentation document used where the API expects a secured
-        verifiable presentation, such as in verify operations and in
+        verifiable presentation, such as in verify operations or in
         verifiablePresentation response envelopes. The document MAY include an
-        embedded proof. An EnvelopedVerifiablePresentation MAY be used instead
+        embedded proof. An EnvelopedVerifiablePresentation MAY be used instead,
         where noted in the API description.
       allOf:
         - $ref: "./Presentation.yml#/components/schemas/PresentationDocument"

--- a/components/VerifiablePresentation.yml
+++ b/components/VerifiablePresentation.yml
@@ -30,8 +30,48 @@ components:
         {
           "@context":
             [
-              "https://www.w3.org/ns/credentials/v2",
-              "https://www.w3.org/ns/credentials/examples/v2",
+                "https://www.w3.org/ns/credentials/v2",
+                "https://www.w3.org/ns/credentials/examples/v2",
             ],
-          "type": ["VerifiablePresentation"],
+          "holder": "did:example:123",
+          "type": "VerifiablePresentation",
+          "verifiableCredential":
+            [
+                "@context":
+                  [
+                      "https://www.w3.org/ns/credentials/v2",
+                      "https://www.w3.org/ns/credentials/examples/v2",
+                  ],
+                "id": "http://example.gov/credentials/3732",
+                "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+                "issuer": "did:example:123",
+                "validFrom": "2020-03-16T22:37:26.544Z",
+                "credentialSubject":
+                  {
+                    "id": "did:example:123",
+                    "degree":
+                      {
+                        "type": "BachelorDegree",
+                        "name": "Bachelor of Science and Arts",
+                      },
+                  },
+                "proof":
+                  {
+                    "type": "DataIntegrityProof",
+                    "cryptosuite": "eddsa-rdfc-2022",
+                    "created": "2020-04-02T18:28:08Z",
+                    "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+                    "proofPurpose": "assertionMethod",
+                    "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
+                  },
+            ],
+          "proof":
+            {
+              "type": "DataIntegrityProof",
+              "cryptosuite": "ecdsa-rdfc-2019",
+              "created": "2020-04-02T18:28:08Z",
+              "verificationMethod": "did:example:123#z6MksHh7qHWvybLg5QTPPdG2DgEjjduBDArV9EF9mRiRzMBN",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "zaHXrr7AQdydBk3ahpCDpWbxfLokDqmCToYm2dyWvpcFVyWooC2he63w1f7UNQoAMKdhaRtcnaE2KTo5o5vTCcfw",
+            },
         }

--- a/index.html
+++ b/index.html
@@ -976,6 +976,17 @@ exercise API behavior; data model conformance is out of scope for this
 specification and is covered by separate test suites.
         </p>
         <p>
+OpenAPI uses separate schema names for the same sparse property table
+where the API distinguishes roles: <code>Credential</code> and
+<code>Presentation</code> for input documents (for example,
+<code>credential</code> in an issue request), and
+<code>VerifiableCredential</code> and <code>VerifiablePresentation</code>
+where a secured artifact is expected (for example,
+<code>verifiableCredential</code> in a response). The schemas share the
+same underlying document shape; the names signal API usage rather than
+different normative data model requirements.
+        </p>
+        <p>
 Where this specification needs to express support for alternate
 serializations at the API boundary, it does so explicitly through
 <code>EnvelopedVerifiableCredential</code>,

--- a/index.html
+++ b/index.html
@@ -955,6 +955,36 @@ endpoints defined by this specification MUST be serialized as JSON and include
 the `Content-Type` header with a media type value of `application/json`.
         </p>
       </section>
+      <section class="informative notoc">
+        <h3>Credential and Presentation Objects in API Descriptions</h3>
+        <p>
+The OpenAPI descriptions in this specification represent
+[=verifiable credential=] and [=verifiable presentation=] request and
+response bodies using a minimal property table: <code>@context</code> and
+<code>type</code>. This keeps the API description focused on what VCALM
+defines — HTTP endpoints, request and response structure,
+<code>options</code>, workflows, exchanges, and related coordinator and
+service behavior — rather than repeating the full graph of a
+[=verifiable credential=] or [=verifiable presentation=] in every endpoint
+table.
+        </p>
+        <p>
+The semantic content of credentials and presentations exchanged through
+these APIs is defined by the Verifiable Credentials ecosystem specifications
+that apply to a given deployment. VCALM interop testing is intended to
+exercise API behavior; data model conformance is out of scope for this
+specification and is covered by separate test suites.
+        </p>
+        <p>
+Where this specification needs to express support for alternate
+serializations at the API boundary, it does so explicitly through
+<code>EnvelopedVerifiableCredential</code>,
+<code>EnvelopedVerifiablePresentation</code>, and negotiation properties such
+as <code>acceptedEnvelopes</code> and <code>acceptedCryptosuites</code> in
+[=verifiable presentation requests=]. See Section
+[[[#requesting-a-presentation]]].
+        </p>
+      </section>
       <section class="notoc">
         <h4>Payload Sizes</h4>
         <p>

--- a/oas.yaml
+++ b/oas.yaml
@@ -875,24 +875,7 @@ components:
             "@context": [
               "https://www.w3.org/ns/credentials/v2"
             ],
-            "id": "https://issuer.example.com/credentials/status/lists/abc123",
-            "type": ["VerifiableCredential", "BitstringStatusListCredential"],
-            "issuer": "did:example:issuer",
-            "validFrom": "2024-01-01T00:00:00Z",
-            "credentialSubject": {
-              "id": "https://issuer.example.com/credentials/status/lists/abc123#list",
-              "type": "BitstringStatusList",
-              "statusPurpose": "revocation",
-              "encodedList": "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAACAP2A1AQAAZQAAAIA..."
-            },
-            "proof": {
-              "type": "DataIntegrityProof",
-              "cryptosuite": "eddsa-rdfc-2022",
-              "verificationMethod": "did:example:issuer#key-1",
-              "created": "2024-01-01T00:00:00Z",
-              "proofPurpose": "assertionMethod",
-              "proofValue": "z..."
-            }
+            "type": ["VerifiableCredential", "BitstringStatusListCredential"]
           }
         }
     IssueCredentialRequest:

--- a/oas.yaml
+++ b/oas.yaml
@@ -899,7 +899,7 @@ components:
       type: object
       properties:
         credential:
-          $ref: "./components/Credential.yml#/components/schemas/UnsecuredCredential"
+          $ref: "./components/Credential.yml#/components/schemas/Credential"
         options:
           $ref: "./components/IssueCredentialOptions.yml#/components/schemas/IssueCredentialOptions"
     IssueCredentialResponse:

--- a/oas.yaml
+++ b/oas.yaml
@@ -875,7 +875,24 @@ components:
             "@context": [
               "https://www.w3.org/ns/credentials/v2"
             ],
-            "type": ["VerifiableCredential", "BitstringStatusListCredential"]
+            "id": "https://issuer.example.com/credentials/status/lists/abc123",
+            "type": ["VerifiableCredential", "BitstringStatusListCredential"],
+            "issuer": "did:example:issuer",
+            "validFrom": "2024-01-01T00:00:00Z",
+            "credentialSubject": {
+              "id": "https://issuer.example.com/credentials/status/lists/abc123#list",
+              "type": "BitstringStatusList",
+              "statusPurpose": "revocation",
+              "encodedList": "H4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAACAP2A1AQAAZQAAAIA..."
+            },
+            "proof": {
+              "type": "DataIntegrityProof",
+              "cryptosuite": "eddsa-rdfc-2022",
+              "verificationMethod": "did:example:issuer#key-1",
+              "created": "2024-01-01T00:00:00Z",
+              "proofPurpose": "assertionMethod",
+              "proofValue": "z..."
+            }
           }
         }
     IssueCredentialRequest:


### PR DESCRIPTION
## Summary

Fixes #653

This PR simplifies how credential and presentation objects appear in VCALM's OpenAPI-generated property tables. The goal is to reduce noise and avoid implying that VCALM re-specifies Verifiable Credentials Data Model constraints in every endpoint section.

## Where we landed

**Keep the examples.** Full illustrative JSON examples (`id`, `issuer`, `credentialSubject`, `proof`, `holder`, `verifiableCredential`, etc.) are restored from `main` so readers still see realistic request/response payloads.

**Remove normative property tables from OAS.** OpenAPI schema definitions for credential and presentation objects now document only `@context` and `type`. We removed inlined VCDM property trees and normative phrasing such as "Each item in the `@context` array MUST be a string" from the OAS component files.

**Keep VCALM-specific normative scope elsewhere.** VCALM normative requirements remain focused on HTTP endpoints, `options`, workflows, exchanges, interactions, enveloped types, and presentation-request negotiation (`acceptedEnvelopes`, `acceptedCryptosuites`). VC data model conformance is not re-stated here and continues to be covered by separate test suites.

**Add informative rationale in the spec.** A new informative subsection in §2.4 Architecture — *Credential and Presentation Objects in API Descriptions* — explains why the OpenAPI tables are sparse and where VCALM does define format-related API behavior.

## Before / after

| | Before | After |
|---|--------|-------|
| Property tables | Full VCDM graph inlined per endpoint (`issuer`, `proof`, …) | `@context` and `type` only |
| Examples | Full VC/VP illustrations | Unchanged — full examples kept |
| OAS normative text | MUST/SHOULD on array item types, nested property requirements | Removed from credential/presentation OAS descriptions |
| Enveloped types | Minimal envelope descriptors | Unchanged |

## Files changed

- `components/Credential.yml` — `Credential`, `UnsecuredCredential`
- `components/VerifiableCredential.yml`
- `components/Presentation.yml`
- `components/VerifiablePresentation.yml`
- `oas.yaml` — `CreateStatusListResponse` example restored
- `index.html` — informative note on simplified OAS tables

## Test plan

- [x] `npm run lint` passes (`openapi lint oas.yaml`)
- [ ] Review rendered spec tables in PR preview
- [ ] Confirm WG agrees sparse OAS tables + full examples is the right balance


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 14, 2026, 7:32 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=respec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2FOpSecId%2Fvcalm%2F308d4e8b7b221d616af1a59d1fc5c38724f7a864%2Findex.html%3FisPreview%3Dtrue)

**Error output:**

```
EISDIR: illegal operation on a directory, open 'uploads/GNbMlN/'
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/vcalm%23661.)._

</details>
