### PR TITLE
Add support for retrieving current exchange VPR

### DIFF
--- a/index.html
+++ b/index.html
@@ -2828,7 +2828,7 @@ and perform an HTTP GET on the `vcapi` URL concatenated with `/request`.
         <p>
 This feature allows the browser to route their requests through the
 [=coordinator=]'s origin (thereby anchoring the entire operation in said origin),
-through to the delegate they have approved as a service provider.
+to the delegate they have approved as a service provider.
 This convenience exists whether the request is made on the same device or
 forwarded for a cross-device request.
         </p>

--- a/index.html
+++ b/index.html
@@ -2829,7 +2829,7 @@ and perform an HTTP GET on the `vcapi` URL concatenated with `/request`.
 
         <p>
 This feature allows the browser to route their requests through the
-[=coordinator=]'s origin (thereby anchoring the entire operation in said origin),
+[=coordinator's=] origin (thereby anchoring the entire operation in said origin),
 to the delegate they have approved as a service provider.
 This convenience exists whether the request is made on the same device or
 forwarded for a cross-device request.

--- a/index.html
+++ b/index.html
@@ -2806,6 +2806,52 @@ links to resources from other domains to render a web page.
       <section>
         <!--If this header is changed, also update the x-componentTableLink parameter for this endpoint in the oas.yaml file.
             If the x-componentTableLink isn't updated to match the corresponding Component Table link will break.-->
+        <h4>Get Initial Exchange VPR</h4>
+        <p>
+This endpoint MUST return the initial [=verifiable presentation request=] to be returned by an exchange
+when accessed with an `Accept` header value of `application/json`. Processing this
+request SHOULD not advance the exchange to a new step nor perform any
+state-changing side effects, such as credential issuance.
+        </p>
+
+        <div class="api-detail"
+          data-api-endpoint="get /workflows/{localWorkflowId}/exchanges/{localExchangeId}/request"></div>
+
+        <p>
+This might be a useful endpoint for integration with the [[[DCAPI]]].
+To make a [[DCAPI]] request backed by the VCALM protocol, the [=coordinator=]
+MUST provide the [=interaction URL=] as the request data. Subsequently, the
+browser MUST fetch the [=interaction URL=], retrieve the supported protocols,
+and perform an HTTP GET on the `vcapi` URL concatenated with `/request`.
+        </p>
+
+        <p>
+This feature allows the browser to route their requests through the
+[=coordinator=]'s origin (thereby anchoring the entire operation in said origin)
+through to the delegate they have approved as a service provider.
+This convenience exists whether the request is made on the same device or
+forwarded for a cross-device request.
+        </p>
+
+        <p>
+Finally, this endpoint operates without the need for signed requests, as it MAY
+rely on TLS and existing CA infrastructure, without the need for new certificates
+nor a need to incorporate those into the exchange protocol in an additive way.
+However, if we find that the [[DCAPI]] or other supported protocols require
+signed requests or encrypted responses, then the request MAY be returned as a
+signed object referencing a public key that SHOULD be used to encrypt the response.
+Upon receipt of the (potentially encrypted) response, the [=coordinator=] could
+decrypt and deliver the response to the appropriate exchange or delegate decryption
+support to the exchange service altogether. The official decision on which interface
+VCALM prescribes for performing this functionality is in flux as the [[DCAPI]] rules
+continue to evolve.
+        </p>
+
+      </section>
+
+      <section>
+        <!--If this header is changed, also update the x-componentTableLink parameter for this endpoint in the oas.yaml file.
+            If the x-componentTableLink isn't updated to match the corresponding Component Table link will break.-->
         <h4>Participate in an Exchange</h4>
         <p>
 A server MAY include a <code>referenceId</code> property in an exchange
@@ -3276,7 +3322,7 @@ on how to start an interaction with the remote system.
         </p>
 
         <p>
-When the [=interaction URL=] is fetched using an `Accept` header of
+When the [=interaction URL=] is fetched using an `Accept` header value of
 `application/json`, a single JSON object containing a `protocols` [=map=] MUST
 be returned where each [=map/key=] is a protocol identifier and each
 [=map/value=] is a URL that can be used to initiate the interaction. For
@@ -3313,7 +3359,7 @@ the `saas.example` domain in the list of protocols.
         </p>
 
         <p>
-When the [=interaction URL=] is fetched using any unrecognized `Accept` header,
+When the [=interaction URL=] is fetched using any unrecognized `Accept` header value,
 a `text/html` document MUST be returned with directions instructing a human
 being to use specific software that understands how to process interaction URLs.
         </p>

--- a/index.html
+++ b/index.html
@@ -2806,9 +2806,9 @@ links to resources from other domains to render a web page.
       <section>
         <!--If this header is changed, also update the x-componentTableLink parameter for this endpoint in the oas.yaml file.
             If the x-componentTableLink isn't updated to match the corresponding Component Table link will break.-->
-        <h4>Get Initial Exchange VPR</h4>
+        <h4>Get Current Exchange VPR</h4>
         <p>
-This endpoint MUST return the initial [=verifiable presentation request=] to be returned by an exchange
+This endpoint MUST return the current [=verifiable presentation request=] to be returned by an exchange
 when accessed with an `Accept` header value of `application/json`. Processing this
 request SHOULD not advance the exchange to a new step nor perform any
 state-changing side effects, such as credential issuance.

--- a/index.html
+++ b/index.html
@@ -2810,7 +2810,7 @@ links to resources from other domains to render a web page.
         <p>
 This endpoint MUST return the current [=verifiable presentation request=] to be returned by an exchange
 when accessed with an `Accept` header value of `application/json`. Processing this
-request SHOULD not advance the exchange to a new step nor perform any
+request SHOULD NOT advance the exchange to a new step nor perform any
 state-changing side effects, such as credential issuance.
         </p>
 
@@ -2827,7 +2827,7 @@ and perform an HTTP GET on the `vcapi` URL concatenated with `/request`.
 
         <p>
 This feature allows the browser to route their requests through the
-[=coordinator=]'s origin (thereby anchoring the entire operation in said origin)
+[=coordinator=]'s origin (thereby anchoring the entire operation in said origin),
 through to the delegate they have approved as a service provider.
 This convenience exists whether the request is made on the same device or
 forwarded for a cross-device request.
@@ -2835,7 +2835,7 @@ forwarded for a cross-device request.
 
         <p>
 Finally, this endpoint operates without the need for signed requests, as it MAY
-rely on TLS and existing CA infrastructure, without the need for new certificates
+rely on TLS and existing CA infrastructure, without a need for new certificates
 nor a need to incorporate those into the exchange protocol in an additive way.
 However, if we find that the [[DCAPI]] or other supported protocols require
 signed requests or encrypted responses, then the request MAY be returned as a

--- a/index.html
+++ b/index.html
@@ -2811,7 +2811,9 @@ links to resources from other domains to render a web page.
 This endpoint MUST return the current [=verifiable presentation request=] to be returned by an exchange
 when accessed with an `Accept` header value of `application/json`. Processing this
 request SHOULD NOT advance the exchange to a new step nor perform any
-state-changing side effects, such as credential issuance.
+state-changing side effects, such as credential issuance. If there is no [=verifiable presentation request=]
+available for the exchange in the current step, the value of the `verifiablePresentationRequest` property
+returned by this endpoint MUST be an empty JSON object.
         </p>
 
         <div class="api-detail"

--- a/oas.yaml
+++ b/oas.yaml
@@ -357,7 +357,7 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: getCurrentExchangeVpr
-      description: Gets the current VPR for an exchange. This might be a useful endpoint for integration with the DC API. Processing this request SHOULD not advance the exchange to a new step nor perform any state-changing side effects, such as credential issuance.
+      description: Gets the current VPR for an exchange (if available). This might be a useful endpoint for integration with the DC API. Processing this request SHOULD not advance the exchange to a new step nor perform any state-changing side effects, such as credential issuance.
       x-expectedCaller: Anyone with provided URL
       x-componentTableLink: "get-current-exchange-vpr"
       parameters:

--- a/oas.yaml
+++ b/oas.yaml
@@ -347,6 +347,35 @@ paths:
           description: Not Authorized
         "500":
           description: Internal Error
+  /workflows/{localWorkflowId}/exchanges/{localExchangeId}/request:
+    get:
+      summary: Gets the initial VPR for a specific exchange.
+      tags:
+        - Exchanges
+      security:
+        - networkAuth: []
+        - oAuth2: []
+        - zCap: []
+      operationId: getInitialExchangeVpr
+      description: Gets the initial VPR for a specific exchange. This might be a useful endpoint for integration with the DC API. Processing this request SHOULD not advance the exchange to a new step nor perform any state-changing side effects, such as credential issuance.
+      x-expectedCaller: Anyone with provided URL
+      x-componentTableLink: "get-initial-exchange-vpr"
+      parameters:
+        - $ref: "./components/parameters/path/LocalWorkflowId.yml"
+        - $ref: "./components/parameters/path/LocalExchangeId.yml"
+      responses:
+        "200":
+          description: Initial VPR to be returned by the exchange.
+          content:
+            application/json:
+              schema:
+                $ref: "./components/VerifiablePresentationRequest.yml#/components/schemas/VerifiablePresentationRequest"
+        "400":
+          description: Invalid input
+        "401":
+          description: Not Authorized
+        "500":
+          description: Internal Error
   /credentials/{id}:
     get:
       tags:

--- a/oas.yaml
+++ b/oas.yaml
@@ -349,31 +349,27 @@ paths:
           description: Internal Error
   /workflows/{localWorkflowId}/exchanges/{localExchangeId}/request:
     get:
-      summary: Gets the initial VPR for a specific exchange.
+      summary: Gets the current VPR for a specific exchange.
       tags:
         - Exchanges
       security:
         - networkAuth: []
         - oAuth2: []
         - zCap: []
-      operationId: getInitialExchangeVpr
-      description: Gets the initial VPR for a specific exchange. This might be a useful endpoint for integration with the DC API. Processing this request SHOULD not advance the exchange to a new step nor perform any state-changing side effects, such as credential issuance.
+      operationId: getCurrentExchangeVpr
+      description: Gets the current VPR for a specific exchange. This might be a useful endpoint for integration with the DC API. Processing this request SHOULD not advance the exchange to a new step nor perform any state-changing side effects, such as credential issuance.
       x-expectedCaller: Anyone with provided URL
-      x-componentTableLink: "get-initial-exchange-vpr"
+      x-componentTableLink: "get-current-exchange-vpr"
       parameters:
         - $ref: "./components/parameters/path/LocalWorkflowId.yml"
         - $ref: "./components/parameters/path/LocalExchangeId.yml"
       responses:
         "200":
-          description: Initial VPR to be returned by the exchange.
+          description: Current VPR to be returned by the exchange.
           content:
             application/json:
               schema:
                 $ref: "./components/VerifiablePresentationRequest.yml#/components/schemas/VerifiablePresentationRequest"
-        "400":
-          description: Invalid input
-        "401":
-          description: Not Authorized
         "500":
           description: Internal Error
   /credentials/{id}:

--- a/oas.yaml
+++ b/oas.yaml
@@ -349,7 +349,7 @@ paths:
           description: Internal Error
   /workflows/{localWorkflowId}/exchanges/{localExchangeId}/request:
     get:
-      summary: Gets the current VPR for a specific exchange.
+      summary: Gets the current VPR for an exchange.
       tags:
         - Exchanges
       security:
@@ -357,7 +357,7 @@ paths:
         - oAuth2: []
         - zCap: []
       operationId: getCurrentExchangeVpr
-      description: Gets the current VPR for a specific exchange. This might be a useful endpoint for integration with the DC API. Processing this request SHOULD not advance the exchange to a new step nor perform any state-changing side effects, such as credential issuance.
+      description: Gets the current VPR for an exchange. This might be a useful endpoint for integration with the DC API. Processing this request SHOULD not advance the exchange to a new step nor perform any state-changing side effects, such as credential issuance.
       x-expectedCaller: Anyone with provided URL
       x-componentTableLink: "get-current-exchange-vpr"
       parameters:
@@ -369,7 +369,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "./components/VerifiablePresentationRequest.yml#/components/schemas/VerifiablePresentationRequest"
+                $ref: "#/components/schemas/GetCurrentExchangeVprResponse"
         "500":
           description: Internal Error
   /credentials/{id}:
@@ -1153,6 +1153,13 @@ components:
             OID4VCI:
               type: string
               description: The URL to use when initiating an OID4VCI issuance.
+    GetCurrentExchangeVprResponse:
+      type: object
+      additionalProperties: false
+      description: The current VPR for an exchange.
+      properties:
+        verifiablePresentationRequest:
+          $ref: "./components/VerifiablePresentationRequest.yml#/components/schemas/VerifiablePresentationRequest"
     GetExchangeResponse:
       type: object
       additionalProperties: false


### PR DESCRIPTION
This PR addresses Issue #633 by adding an endpoint to retrieve the current VPR in an exchange, a feature we expect will be needed for DC API and potentially other protocols in the future.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 11, 2026, 9:55 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=respec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fvcalm%2F461417f83a3ec134d083eafbabc239533f64bea7%2Findex.html%3FisPreview%3Dtrue)

**Error output:**

```
EISDIR: illegal operation on a directory, open 'uploads/bt1tqm/'
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/vcalm%23663.)._

</details>
