### PR TITLE
Add extra hints about using interaction URL as `redirectUrl` value

### DIFF
--- a/index.html
+++ b/index.html
@@ -3315,7 +3315,7 @@ the `saas.example` domain in the list of protocols.
         <p>
 When the [=interaction URL=] is fetched using any unrecognized `Accept` header,
 a `text/html` document MUST be returned with directions instructing a human
-being to use specific software that understands how to process [=interaction URL=]s.
+being to use specific software that understands how to process [=interaction URLs=].
         </p>
 
         <p class="note" title="Mapping to exchange URLs">
@@ -3323,7 +3323,7 @@ Some coordinator implementations will implement the protocols endpoint as a pass
 through to a protocols endpoint for an exchange instance. For example, a GET on
 `https://app.example/interactions/z8n38Dp7a?iuv=1` will result in a pass-through
 GET on `https://app.example/workflows/123/exchanges/987/protocols`, which would
-return the response above. Implementing [=interaction URL=]s in this way can
+return the response above. Implementing [=interaction URLs=] in this way can
 provide an easier implementation path.
         </p>
 
@@ -3683,7 +3683,7 @@ accident, as it might include information that is secret to the [=holder=].
       <h3>Use of HTTPS for Interaction URLs</h3>
 
       <p>
-This specification strongly suggests the use of HTTPS for [=interaction URL=]s
+This specification strongly suggests the use of HTTPS for [=interaction URLs=]
 for the following reasons:
       </p>
 

--- a/index.html
+++ b/index.html
@@ -3051,8 +3051,8 @@ QR Code (optical medium), or NFC (wireless medium) &mdash; where the protocol
 does not need to involve this API.
       </p>
       <p>
-The sequence diagram below outlines an [=issuer=] generating an interaction
-URL, using a QR Code to share it with a [=holder=], and proceeding with the
+The sequence diagram below outlines an [=issuer=] generating an [=interaction
+URL=], using a QR Code to share it with a [=holder=], and proceeding with the
 `vcapi` protocol:
       </p>
       <figure>
@@ -3092,8 +3092,8 @@ An issuer-initiated interaction using a QR Code
       </figure>
 
       <p>
-The sequence diagram below outlines a [=verifier=] generating an interaction
-URL, using a QR Code to share it with a [=holder=], and proceeding with the
+The sequence diagram below outlines a [=verifier=] generating an [=interaction
+URL=], using a QR Code to share it with a [=holder=], and proceeding with the
 `vcapi` protocol:
       </p>
       <figure>
@@ -3133,7 +3133,7 @@ A verifier-initiated interaction using a QR Code
       </figure>
 
       <p>
-The sequence diagram below outlines a [=holder=] generating an interaction URL,
+The sequence diagram below outlines a [=holder=] generating an [=interaction URL=],
 using a QR Code to share it with a [=verifier=], and proceeding with the
 `inviteRequest` protocol:
       </p>
@@ -3173,9 +3173,9 @@ A holder-initiated interaction using a QR Code
         <h4>Interaction URL Format</h4>
         <p>
 The format of the <dfn>interaction URL</dfn> MUST conform to the syntax for the
-[[[URL]]] and contain an `iuv` query parameter encoding the interaction URL
+[[[URL]]] and contain an `iuv` query parameter encoding the [=interaction URL=]
 version number, which MUST be `1` when using this version of this API. The
-interaction URL SHOULD be an HTTPS URL that contains an interaction-specific
+[=interaction URL=] SHOULD be an HTTPS URL that contains an interaction-specific
 identifier. The URL SHOULD be opaque and require no URL syntax processing before
 it is fetched by the receiving system. An example of such a URL is shown below:
         </p>
@@ -3189,16 +3189,16 @@ Protocols that encode lengthy protocol-specific information into URLs suffer
 from limitations placed by software libraries on the maximum allowable length of a URL.
 At the time of writing, the suggested URL length limit is roughly 2,000
 characters. Implementers SHOULD NOT put information that can be expressed in the
-response to a GET request for an interaction URL, defined in Section
+response to a GET request for an [=interaction URL=], defined in Section
 [[[#interaction-protocols-response]]], into the query parameters of the
-interaction URL.
+[=interaction URL=].
         </p>
       </section>
 
         <p class="note" title="Interactions URL lives on Coordinators, not Workflow Services">
-A coordinator has the freedom to put the interaction URL at any location on its Web origin, because
+A coordinator has the freedom to put the [=interaction URL=] at any location on its Web origin, because
 it is expected to be considered opaque by consuming software (except for the `iuv` query parameter).
-However, it is important that the interaction URL be hosted on a coordinator and NOT hosted at the
+However, it is important that the [=interaction URL=] be hosted on a coordinator and NOT hosted at the
 workflow service. This enables the coordinator's Web origin (DNS domain name) to be used as a consistent trust signal by
 consumers and the application of business rules that might modulate actions.
 
@@ -3315,7 +3315,7 @@ the `saas.example` domain in the list of protocols.
         <p>
 When the [=interaction URL=] is fetched using any unrecognized `Accept` header,
 a `text/html` document MUST be returned with directions instructing a human
-being to use specific software that understands how to process interaction URLs.
+being to use specific software that understands how to process [=interaction URL=]s.
         </p>
 
         <p class="note" title="Mapping to exchange URLs">
@@ -3323,7 +3323,7 @@ Some coordinator implementations will implement the protocols endpoint as a pass
 through to a protocols endpoint for an exchange instance. For example, a GET on
 `https://app.example/interactions/z8n38Dp7a?iuv=1` will result in a pass-through
 GET on `https://app.example/workflows/123/exchanges/987/protocols`, which would
-return the response above. Implementing interaction URLs in this way can
+return the response above. Implementing [=interaction URL=]s in this way can
 provide an easier implementation path.
         </p>
 
@@ -3683,7 +3683,7 @@ accident, as it might include information that is secret to the [=holder=].
       <h3>Use of HTTPS for Interaction URLs</h3>
 
       <p>
-This specification strongly suggests the use of HTTPS for interaction URLs
+This specification strongly suggests the use of HTTPS for [=interaction URL=]s
 for the following reasons:
       </p>
 

--- a/oas.yaml
+++ b/oas.yaml
@@ -1103,7 +1103,7 @@ components:
           properties:
             redirectUrl:
               type: string
-              description: The URL the exchange wishes to redirect the client to.
+              description: The URL the exchange wishes to redirect the client to. A server MAY also send an interaction URL to the client as a redirectUrl, inviting the client to automatically initiate another exchange. In this case, a client that understands interaction URLs MAY retrieve the protocols associated with the interaction URL and start the exchange. A client that does not understand interaction URLs MAY direct the holder to the redirectUrl in the browser, where an HTML page MAY display next steps.
             referenceId:
               type: string
               description: An optional identifier to correlate exchange messages. A server MAY include this value; if present, the client SHOULD include it in its next message. The value SHOULD be a <code>urn:uuid</code> value.


### PR DESCRIPTION
This PR addresses Issue #619 by adding extra hints to the usage of an interaction URL as a `redirectUrl` at the end of an exchange.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 11, 2026, 5:43 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=respec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fkezike%2Fvcalm%2Ff3c47cde9a2284d8e15cf4297fa8b818f2ec1a73%2Findex.html%3FisPreview%3Dtrue)

**Error output:**

```
EISDIR: illegal operation on a directory, open 'uploads/pbbw6n/'
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/vcalm%23679.)._

</details>
