### PR TITLE
Fix respec-oas RENDER ERROR on Credential/Presentation schemas

### DIFF
--- a/components/Credential.yml
+++ b/components/Credential.yml
@@ -27,6 +27,7 @@ components:
           items:
             type: string
     Credential:
+      type: object
       description: >
         A JSON-LD credential document used where the API expects an input
         credential to be issued or processed, such as in

--- a/components/Presentation.yml
+++ b/components/Presentation.yml
@@ -27,6 +27,7 @@ components:
           items:
             type: string
     Presentation:
+      type: object
       description: >
         A JSON-LD presentation document used where the API expects an input
         presentation to be created or processed, such as in

--- a/components/VerifiableCredential.yml
+++ b/components/VerifiableCredential.yml
@@ -13,6 +13,7 @@ paths:
 components:
   schemas:
     VerifiableCredential:
+      type: object
       description: >
         A JSON-LD credential document used where the API expects a secured
         verifiable credential, such as in verify or derive operations, or in

--- a/components/VerifiablePresentation.yml
+++ b/components/VerifiablePresentation.yml
@@ -13,6 +13,7 @@ paths:
 components:
   schemas:
     VerifiablePresentation:
+      type: object
       description: >
         A JSON-LD presentation document used where the API expects a secured
         verifiable presentation, such as in verify operations or in


### PR DESCRIPTION
## Summary
- respec-oas@1.0.1 fails to render property schemas that use `allOf` without a top-level `type` (falls through to `RENDER ERROR` and dumps the JSON schema).
- The published TR shows **12** of these errors; all resolve to four role wrappers: `Credential`, `VerifiableCredential`, `Presentation`, `VerifiablePresentation`.
- Add `type: object` beside each `allOf` so the renderer takes the object path and merges `allOf` properties. Shared `CredentialDocument` / `PresentationDocument` bases are unchanged.

## Affected endpoints (all 12 cells)
1. §3.2.1 Issue Credential — `credential`
2. §3.3.1 Verify Credential — `verifiableCredential`
3. §3.3.2 Verify Presentation — `verifiablePresentation`
4. §3.3.2 Verify Presentation — `presentation`
5. §3.5.1 Derive Credential — `verifiableCredential`
6. §3.5.2 Create Presentation — `presentation`
7. §3.6.1 Create Workflow — nested under `steps`
8. §3.6.2 Get Workflow Configuration — `200`
9. §3.6.5 Participate in an Exchange — `verifiablePresentation`
10. §3.6.5 Participate in an Exchange — `200`
11. §3.6.6 Get Exchange State — `200`
12. Appendix C.1 Create Status List — `201`

## Test plan
- [ ] Open editor's draft / local `npm run serve` and confirm the 12 property tables no longer show `RENDER ERROR`
- [ ] Spot-check Issue Credential / Verify Presentation tables show `@context` and `type` from the document schemas
- [ ] `npm run lint` (OpenAPI) still passes


Made with [Cursor](https://cursor.com)