### PR TITLE
Add informative reference workflow step processing appendix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1730,6 +1730,397 @@ formats are also acceptable.
           such as <code>bbs-2023</code> or <code>ecdsa-sd-2023</code> in the <code>acceptedCryptosuites</code> array.
         </p>
 
+        <section>
+          <h4 id="matching-a-credential-to-a-querybyexample">Matching a Credential to a QueryByExample</h4>
+
+          <p>
+The following algorithm specifies how a conforming [=holder=] implementation
+determines whether a [=verifiable credential=] matches the selection criteria
+in a QueryByExample <code>credentialQuery</code> object. Required inputs are a
+[=verifiable credential=] ([=map=] <var>credential</var>) and a
+<code>credentialQuery</code> object ([=map=] <var>credentialQuery</var>). A
+boolean match result is produced as output. A conforming implementation MUST
+produce the same output as this algorithm.
+          </p>
+
+          <p>
+Matching proceeds in two stages. First, if an <code>example</code> is present,
+each of its properties is treated as a requirement against
+<var>credential</var>. Second, if <code>acceptedIssuers</code> is present, the
+credential's issuer MUST be acceptable. The credential matches only if both
+stages succeed when present.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If <var>credential</var> is not a [=map=], return <code>false</code>.
+            </li>
+            <li>
+If <var>credentialQuery</var> contains an <code>example</code> property,
+initialize <var>example</var> to its value and perform the following steps:
+              <ol class="algorithm">
+                <li>
+If <var>example</var> contains an <code>@context</code> property, initialize
+<var>expectedContexts</var> to its value normalized to a [=list=], and
+initialize <var>credentialContexts</var> to the value of the
+<code>@context</code> property of <var>credential</var> normalized to a
+[=list=]. If the length of <var>credentialContexts</var> is less than the
+length of <var>expectedContexts</var>, return <code>false</code>. For each
+index <var>i</var> from <code>0</code> to the length of
+<var>expectedContexts</var> minus one, if
+<var>expectedContexts</var>[<var>i</var>] is not strictly equal to
+<var>credentialContexts</var>[<var>i</var>], return <code>false</code>.
+                </li>
+                <li>
+If <var>example</var> contains a <code>type</code> property, initialize
+<var>expectedTypes</var> to its value normalized to a [=list=], and initialize
+<var>credentialTypes</var> to the value of the <code>type</code> property of
+<var>credential</var> normalized to a [=list=]. If no value in
+<var>expectedTypes</var> is strictly equal to any value in
+<var>credentialTypes</var>, return <code>false</code>.
+                </li>
+                <li>
+Initialize <var>remaining</var> to a copy of <var>example</var> with the
+<code>@context</code> and <code>type</code> properties removed, if present. If
+<var>remaining</var> contains any properties, set <var>match</var> to the
+result of running the algorithm in Section
+[[[#matching-object-properties]]], passing <var>remaining</var> as
+<var>expectedObject</var> and <var>credential</var> as
+<var>actualObject</var>. If <var>match</var> is <code>false</code>, return
+<code>false</code>.
+                </li>
+              </ol>
+            </li>
+            <li>
+If <var>credentialQuery</var> contains an <code>acceptedIssuers</code>
+property, initialize <var>acceptedIssuers</var> to its value and perform the
+following steps:
+              <ol class="algorithm">
+                <li>
+Initialize <var>credentialIssuer</var> to the value of the
+<code>issuer</code> property of <var>credential</var>. If
+<var>credentialIssuer</var> is a [=map=], initialize
+<var>credentialIssuer</var> to the value of its <code>id</code> property.
+                </li>
+                <li>
+Initialize <var>issuerItems</var> to an empty [=list=]. For each
+<var>item</var> in <var>acceptedIssuers</var>, if <var>item</var> is a
+[=list=], append each of its elements to <var>issuerItems</var>; otherwise,
+append <var>item</var> to <var>issuerItems</var>.
+                </li>
+                <li>
+If no <var>item</var> in <var>issuerItems</var> is acceptable for
+<var>credentialIssuer</var>, return <code>false</code>. An <var>item</var> is
+acceptable if any of the following is true:
+                  <ol class="algorithm">
+                    <li>
+<var>item</var> is a [=string=] that is strictly equal to
+<var>credentialIssuer</var>.
+                    </li>
+                    <li>
+<var>item</var> is a [=map=] that contains an <code>id</code> property whose
+value is strictly equal to <var>credentialIssuer</var>.
+                    </li>
+                    <li>
+<var>item</var> is a [=map=] that contains a <code>recognizedIn</code>
+property, and <var>credentialIssuer</var> is recognized according to the
+[[[VC-RECOG-ENT]]] specification using that property's value.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li>
+Return <code>true</code>.
+            </li>
+          </ol>
+
+          <p class="note" title="Properties not used during matching">
+The <code>reason</code>, <code>acceptedCryptosuites</code>, and
+<code>acceptedEnvelopes</code> properties of a <code>credentialQuery</code>
+object are not used during credential matching. The <code>reason</code>
+property is intended for display to the [=holder=] by their software. The
+<code>acceptedCryptosuites</code> and <code>acceptedEnvelopes</code> properties
+inform the [=holder=]'s software about which proof mechanisms and envelope
+formats the [=verifier=] will accept, and are used during presentation
+construction rather than credential selection.
+          </p>
+
+          <p class="note" title="JSON structural matching">
+This algorithm compares JSON structure and values. It does not require JSON-LD
+compaction, expansion, or term rewriting. Implementations MAY apply JSON-LD
+transformations before matching, provided the boolean result is the same as
+this algorithm when run on the transformed inputs.
+          </p>
+        </section>
+
+        <section>
+          <h5 id="matching-object-properties">Matching Object Properties</h5>
+
+          <p>
+The following algorithm determines whether every property of an expected object
+is satisfied by an actual object. It is used recursively for nested objects
+such as <code>credentialSubject</code>. Required inputs are an expected object
+([=map=] <var>expectedObject</var>) and an actual object ([=map=]
+<var>actualObject</var>). A boolean is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+For each <var>propertyName</var> and <var>expectedValue</var> pair in
+<var>expectedObject</var>:
+              <ol class="algorithm">
+                <li>
+If <var>actualObject</var> does not contain a property named
+<var>propertyName</var>, return <code>false</code>.
+                </li>
+                <li>
+Initialize <var>actualValue</var> to the value of the
+<var>propertyName</var> property of <var>actualObject</var>.
+                </li>
+                <li>
+If <var>expectedValue</var> is an empty [=string=] (<code>""</code>), continue
+to the next property. An empty string indicates that the property MUST exist,
+but any value is acceptable.
+                </li>
+                <li>
+If <var>expectedValue</var> is a [=map=]:
+                  <ol class="algorithm">
+                    <li>
+If <var>expectedValue</var> contains no properties, continue to the next
+property. An empty map indicates that the property MUST exist, but any value is
+acceptable.
+                    </li>
+                    <li>
+If <var>actualValue</var> is a [=list=], then at least one element in
+<var>actualValue</var> MUST be a [=map=] for which this algorithm returns
+<code>true</code> when called with <var>expectedValue</var> as
+<var>expectedObject</var> and the element as <var>actualObject</var>. If no
+such element exists, return <code>false</code>.
+                    </li>
+                    <li>
+Otherwise, set <var>nestedMatch</var> to the result of running this algorithm
+with <var>expectedValue</var> as <var>expectedObject</var> and
+<var>actualValue</var> as <var>actualObject</var>. If <var>nestedMatch</var> is
+<code>false</code>, return <code>false</code>.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+If <var>expectedValue</var> is a [=list=]:
+                  <ol class="algorithm">
+                    <li>
+If <var>expectedValue</var> contains no elements, continue to the next
+property. An empty list indicates that the property MUST exist, but any value
+is acceptable.
+                    </li>
+                    <li>
+Initialize <var>actualValues</var> to <var>actualValue</var> normalized to a
+[=list=] (if <var>actualValue</var> is not already a [=list=], wrap it in a
+[=list=] containing only <var>actualValue</var>).
+                    </li>
+                    <li>
+If no element in <var>actualValues</var> is strictly equal to any element in
+<var>expectedValue</var>, return <code>false</code>.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+Otherwise, <var>expectedValue</var> is a primitive value. Initialize
+<var>actualValues</var> to <var>actualValue</var> normalized to a [=list=]. At
+least one element in <var>actualValues</var> MUST satisfy one of the following:
+                  <ol class="algorithm">
+                    <li>
+The element is strictly equal to <var>expectedValue</var>.
+                    </li>
+                    <li>
+Numeric coercion: both the element and <var>expectedValue</var> can be
+interpreted as numeric values, and their numeric values are equal.
+Implementations SHOULD perform numeric coercion when equivalent numeric values
+are represented differently (for example, the [=string=] <code>"21"</code> and
+the number <code>21</code>). A value is eligible for coercion only if it is a
+[=string=] that represents a valid numeric value in its entirety; strings that
+contain non-numeric characters MUST NOT be coerced.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li>
+Return <code>true</code>.
+            </li>
+          </ol>
+
+          <p class="note" title="Equivalence to JSON Pointer Map approach">
+This recursive property matching algorithm is functionally equivalent to
+flattening the expected object into a map of
+<a href="https://www.rfc-editor.org/rfc/rfc6901">JSON Pointer</a> paths paired
+with expected values, and then checking each path against the credential.
+Implementations MAY use either approach, provided the results are equivalent.
+See also Section [[[#converting-querybyexample-to-json-pointers]]].
+          </p>
+        </section>
+
+        <section>
+          <h4 id="converting-querybyexample-to-json-pointers">Converting QueryByExample to JSON Pointers</h4>
+
+          <p>
+The following algorithm converts a QueryByExample <code>example</code> object
+into a list of <a href="https://www.rfc-editor.org/rfc/rfc6901">JSON
+Pointers</a> that specify which fields to reveal for [=selective disclosure=],
+such as the <code>selectivePointers</code> option used with credential
+derivation (see Section [[[#derive-credential]]]). Required input is an
+example object ([=map=] <var>example</var>). An array of JSON Pointer strings
+(<var>pointers</var>) is produced as output. A conforming implementation that
+converts a QueryByExample <code>example</code> for [=selective disclosure=]
+MUST produce the same output as this algorithm.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize <var>object</var> to a copy of <var>example</var> with the
+<code>@context</code> property removed, if present.
+            </li>
+            <li>
+Initialize <var>pointers</var> to the list of JSON Pointers that identify every
+value in <var>object</var> (for example, by treating <var>object</var> as a
+tree and emitting a pointer for each leaf value).
+            </li>
+            <li>
+Add any VCDM mandatory reveal pointers appropriate for the credential's data
+model version to <var>pointers</var>. For [[VC-DATA-MODEL-2.0]], these include
+at least <code>/type</code> and <code>/issuer</code> when those properties are
+required to be disclosed by the securing mechanism in use.
+            </li>
+            <li>
+Set <var>pointers</var> to the result of running the algorithm in Section
+[[[#adjust-reveal-pointers]]], passing <var>pointers</var>.
+            </li>
+            <li>
+Return <var>pointers</var>.
+            </li>
+          </ol>
+
+          <p>
+The following example uses the Permanent Resident Card QueryByExample from this
+section. After removing <code>@context</code>, generating pointers, adding
+mandatory VCDM 2.0 reveal pointers, ensuring
+<code>credentialSubject</code> coverage, pruning shallow pointers, and
+normalizing <code>type</code> pointers, a conforming conversion produces:
+          </p>
+
+          <pre class="example nohighlight" title="QueryByExample example converted to selectivePointers">
+{
+  "selectivePointers": [
+    "/type",
+    "/issuer",
+    "/credentialSubject/birthCountry"
+  ]
+}
+          </pre>
+
+          <p>
+In this result, <code>/type</code> and <code>/issuer</code> are the explicit
+mandatory reveal pointers for the VC Data Model 2.0 securing mechanism in use,
+and <code>/credentialSubject/birthCountry</code> is the claim requested by the
+example (via an empty-string value). These pointers are suitable for use as
+<code>selectivePointers</code> when deriving a credential for presentation.
+          </p>
+        </section>
+
+        <section>
+          <h5 id="adjust-reveal-pointers">Adjust Reveal Pointers</h5>
+
+          <p>
+The following algorithm adjusts a list of JSON Pointers produced from a
+QueryByExample <code>example</code> so they are suitable for selective
+disclosure. Required input is an array of JSON Pointer strings
+(<var>pointers</var>). An array of JSON Pointer strings is produced as output.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+If no pointer in <var>pointers</var> is equal to
+<code>/credentialSubject</code> and no pointer has
+<code>/credentialSubject/</code> as a prefix, append
+<code>/credentialSubject</code> to <var>pointers</var>.
+            </li>
+            <li>
+Set <var>pointers</var> to the result of running the algorithm in Section
+[[[#prune-shallow-pointers]]], passing <var>pointers</var>.
+            </li>
+            <li>
+Initialize <var>adjustedPointers</var> to an empty [=list=]. For each
+<var>pointer</var> in <var>pointers</var>:
+              <ol class="algorithm">
+                <li>
+Initialize <var>typeIndex</var> to the index of the substring
+<code>/type/</code> in <var>pointer</var>, or <code>-1</code> if it does not
+occur.
+                </li>
+                <li>
+If <var>typeIndex</var> is not <code>-1</code>, append the substring of
+<var>pointer</var> from the start through <code>/type</code> (that is, truncate
+any array index after <code>/type</code>) to <var>adjustedPointers</var>.
+Otherwise, append <var>pointer</var> to <var>adjustedPointers</var>.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return <var>adjustedPointers</var>.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h5 id="prune-shallow-pointers">Prune Shallow Pointers</h5>
+
+          <p>
+The following algorithm retains only the deepest JSON Pointers from a list, so
+that a shallow pointer is removed when a deeper pointer under the same path
+exists. Required input is an array of JSON Pointer strings
+(<var>pointers</var>). An array of JSON Pointer strings is produced as output.
+          </p>
+
+          <p>
+For example, given
+<code>["/a/b", "/a/b/c", "/a/b/c/d"]</code>, the result is
+<code>["/a/b/c/d"]</code>.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Initialize <var>deep</var> to an empty [=list=].
+            </li>
+            <li>
+For each <var>pointer</var> in <var>pointers</var>:
+              <ol class="algorithm">
+                <li>
+Initialize <var>isDeep</var> to <code>true</code>.
+                </li>
+                <li>
+For each <var>other</var> in <var>pointers</var>:
+                  <ol class="algorithm">
+                    <li>
+If the length of <var>pointer</var> is less than the length of
+<var>other</var> and <var>other</var> starts with <var>pointer</var>, set
+<var>isDeep</var> to <code>false</code> and stop comparing for this
+<var>pointer</var>.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+If <var>isDeep</var> is <code>true</code>, append <var>pointer</var> to
+<var>deep</var>.
+                </li>
+              </ol>
+            </li>
+            <li>
+Return <var>deep</var>.
+            </li>
+          </ol>
+        </section>
+
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -1920,8 +1920,29 @@ Initialize <var>actualValues</var> to <var>actualValue</var> normalized to a
 [=list=] containing only <var>actualValue</var>).
                     </li>
                     <li>
-If no element in <var>actualValues</var> is strictly equal to any element in
-<var>expectedValue</var>, return <code>false</code>.
+At least one element <var>expectedElement</var> in <var>expectedValue</var>
+MUST match at least one element <var>actualElement</var> in
+<var>actualValues</var>. An <var>expectedElement</var> matches an
+<var>actualElement</var> if any of the following is true:
+                      <ol class="algorithm">
+                        <li>
+<var>expectedElement</var> is a [=map=], <var>actualElement</var> is a
+[=map=], and this algorithm returns <code>true</code> when called with
+<var>expectedElement</var> as <var>expectedObject</var> and
+<var>actualElement</var> as <var>actualObject</var>.
+                        </li>
+                        <li>
+<var>expectedElement</var> is not a [=map=] and
+<var>actualElement</var> is strictly equal to <var>expectedElement</var>.
+                        </li>
+                        <li>
+<var>expectedElement</var> is not a [=map=] and numeric coercion applies:
+both <var>actualElement</var> and <var>expectedElement</var> can be
+interpreted as numeric values (using the same eligibility rules as for
+primitive values below), and their numeric values are equal.
+                        </li>
+                      </ol>
+If no such matching pair exists, return <code>false</code>.
                     </li>
                   </ol>
                 </li>
@@ -1984,13 +2005,15 @@ Initialize <var>object</var> to a copy of <var>example</var> with the
             <li>
 Initialize <var>pointers</var> to the list of JSON Pointers that identify every
 value in <var>object</var> (for example, by treating <var>object</var> as a
-tree and emitting a pointer for each leaf value).
+tree and emitting a pointer for each leaf value, including properties whose
+value is an empty [=string=]).
             </li>
             <li>
-Add any VCDM mandatory reveal pointers appropriate for the credential's data
-model version to <var>pointers</var>. For [[VC-DATA-MODEL-2.0]], these include
-at least <code>/type</code> and <code>/issuer</code> when those properties are
-required to be disclosed by the securing mechanism in use.
+Append <code>/type</code> and <code>/issuer</code> to <var>pointers</var> if
+they are not already present. These pointers are the deterministic mandatory
+reveal paths for selective disclosure conversion under
+[[VC-DATA-MODEL-2.0]]. Securing mechanisms MAY require additional mandatory
+pointers at issuance time; those are outside the scope of this conversion.
             </li>
             <li>
 Set <var>pointers</var> to the result of running the algorithm in Section
@@ -2003,10 +2026,12 @@ Return <var>pointers</var>.
 
           <p>
 The following example uses the Permanent Resident Card QueryByExample from this
-section. After removing <code>@context</code>, generating pointers, adding
-mandatory VCDM 2.0 reveal pointers, ensuring
-<code>credentialSubject</code> coverage, pruning shallow pointers, and
-normalizing <code>type</code> pointers, a conforming conversion produces:
+section. After removing <code>@context</code>, generating leaf pointers
+(including <code>/credentialSubject/birthCountry</code> from the empty-string
+claim), appending the mandatory <code>/type</code> and <code>/issuer</code>
+pointers, ensuring <code>credentialSubject</code> coverage, pruning shallow
+pointers, and normalizing <code>type</code> pointers, a conforming conversion
+produces:
           </p>
 
           <pre class="example nohighlight" title="QueryByExample example converted to selectivePointers">
@@ -2020,9 +2045,9 @@ normalizing <code>type</code> pointers, a conforming conversion produces:
           </pre>
 
           <p>
-In this result, <code>/type</code> and <code>/issuer</code> are the explicit
-mandatory reveal pointers for the VC Data Model 2.0 securing mechanism in use,
-and <code>/credentialSubject/birthCountry</code> is the claim requested by the
+In this result, <code>/type</code> and <code>/issuer</code> are always added by
+the conversion algorithm as mandatory reveal pointers, and
+<code>/credentialSubject/birthCountry</code> is the claim requested by the
 example (via an empty-string value). These pointers are suitable for use as
 <code>selectivePointers</code> when deriving a credential for presentation.
           </p>

--- a/index.html
+++ b/index.html
@@ -2768,6 +2768,11 @@ Minimum viable examples of both step and credential templates, as well as a coup
 more complex workflow templates, can be found in the appendix <a href="#workflow-step-and-template-examples">Workflow Step and Template Examples</a>.
       </p>
       <p>
+An informative reference algorithm for walking [=exchange=] steps until client
+input is required or a response is ready is provided in Appendix
+[[[#reference-workflow-step-processing-algorithm]]].
+      </p>
+      <p>
 A given interaction with an exchange is expected to be short-lived but
 other mechanisms can be used to enable longer or multi-stage interactions.
 Examples of other interaction mechanisms include SMS, email, web notifications,
@@ -4892,6 +4897,267 @@ and contains a `callbackUrl` to demonstrate the callback feature.
   }
 }
       </pre>
+    </section>
+  </section>
+
+  <section class="appendix informative" id="reference-workflow-step-processing-algorithm">
+    <h2>Reference Workflow Step Processing Algorithm</h2>
+
+    <p>
+This appendix is non-normative.
+    </p>
+
+    <p>
+This specification does not mandate a single internal implementation for
+advancing an [=exchange=]. The algorithm below documents <em>one</em> possible
+approach for walking [=workflow=] steps until the [=workflow service=] must
+return a partial <code>response</code> to the exchange client (for example, to
+ask for a [=verifiable presentation=]), until the exchange completes, or until
+the exchange fails or times out. Implementations MAY differ in ordering,
+persistence, error handling, and protocol bindings.
+    </p>
+
+    <p>
+Hooks such as <code>prepareStep</code>,
+<code>validateReceivedPresentation</code>,
+<code>validateReceivedPresentationRequest</code>, <code>inputRequired</code>,
+<code>createVerifiablePresentationRequest</code>, and
+<code>isStepComplete</code> exist so that the same logical loop can be adapted
+when exchanges are fronted by this HTTP API, OpenID for Verifiable Presentations
+(OID4VP), OpenID for Verifiable Credential Issuance (OID4VCI), invite-based
+flows, or other interaction mechanisms. The <code>response</code> object
+produced when the loop pauses or finishes can be returned directly to clients
+using this API or mapped into other protocol messages as needed.
+    </p>
+
+    <section>
+      <h3 id="process-exchange-steps">Process Exchange Steps</h3>
+
+      <p>
+The following algorithm processes an exchange by repeatedly evaluating the
+current workflow step. Required inputs are a workflow configuration ([=map=]
+<var>workflow</var>) and an exchange ([=map=] <var>exchange</var>). Optional
+inputs are a received [=verifiable presentation=] ([=map=]
+<var>receivedPresentation</var>) and a received [=verifiable presentation
+request=] ([=map=] <var>receivedPresentationRequest</var>). A response object
+([=map=] <var>response</var>), which MAY be empty, is produced as output, or an
+error is raised.
+      </p>
+
+      <ol class="algorithm">
+        <li>
+Initialize <var>step</var> and <var>response</var> to <code>null</code>.
+        </li>
+        <li>
+If <var>exchange</var>.<code>state</code> is <code>complete</code> or
+<code>invalid</code>, throw a <code>NotAllowedError</code>.
+        </li>
+        <li>
+If <var>exchange</var>.<code>state</code> is <code>pending</code>, set it to
+<code>active</code>.
+        </li>
+        <li>
+Continuously loop to process exchange steps, optionally saving any error thrown
+as <var>exchange</var>.<code>lastError</code>. Return out of the loop when a
+full response is generated, input from the exchange client is required, or the
+exchange times out. An implementation-specific maximum step count MAY be
+enforced to handle misconfigured workflows. In each iteration:
+          <ol class="algorithm">
+            <li>
+Set <var>step</var> to the current step (evaluating a step template as needed).
+            </li>
+            <li>
+Call the <code>prepareStep</code> hook, passing <var>workflow</var>,
+<var>exchange</var>, <var>step</var>, <var>receivedPresentation</var>, and
+<var>receivedPresentationRequest</var>, to perform any protocol-specific step
+preparation. If <code>prepareStep</code> returns a result with
+<code>receivedPresentation</code> and/or
+<code>receivedPresentationRequest</code> set, update
+<var>receivedPresentation</var> and/or <var>receivedPresentationRequest</var>
+accordingly.
+            </li>
+            <li>
+If <var>receivedPresentation</var> is set, call
+<code>validateReceivedPresentation</code>, passing <var>workflow</var>,
+<var>exchange</var>, <var>step</var>, and <var>receivedPresentation</var>.
+            </li>
+            <li>
+If <var>receivedPresentationRequest</var> is set, call
+<code>validateReceivedPresentationRequest</code>, passing <var>exchange</var>,
+<var>step</var>, and <var>receivedPresentationRequest</var>.
+            </li>
+            <li>
+If the implementation supports blocking callbacks that can return results to be
+added to exchange variables (or return errors), call the callback and store its
+results in
+<code>exchange.variables.results[exchange.step].callbackResults</code>, or throw
+any error received.
+            </li>
+            <li>
+Set <var>isInputRequired</var> to the result of calling the
+<code>inputRequired</code> hook, passing <var>step</var> and
+<var>receivedPresentation</var>, to perform any protocol-specific input checks.
+            </li>
+            <li>
+If <var>isInputRequired</var> is <code>true</code>:
+              <ol class="algorithm">
+                <li>
+If <var>response</var> is <code>null</code>, set it to an empty object.
+                </li>
+                <li>
+If <var>step</var>.<code>verifiablePresentationRequest</code> is set, call
+<code>createVerifiablePresentationRequest</code>, passing <var>workflow</var>,
+<var>exchange</var>, <var>step</var>, and <var>response</var>.
+                </li>
+                <li>
+Save the exchange (and call any non-blocking callback in the step) and return
+<var>response</var>.
+                </li>
+              </ol>
+            </li>
+            <li>
+Set <var>issueToClient</var> to <code>true</code> if
+<var>step</var>.<code>issueRequests</code> includes any issuer requests for
+[=verifiable credentials=] that are to be sent to the client
+(<code>issueRequest.result</code> is not set); otherwise set it to
+<code>false</code>.
+            </li>
+            <li>
+If <var>step</var>.<code>verifiablePresentation</code> is set or
+<var>issueToClient</var> is <code>true</code>:
+              <ol class="algorithm">
+                <li>
+If <var>response</var> is not <code>null</code>:
+                  <ol class="algorithm">
+                    <li>
+If <var>response</var>.<code>verifiablePresentationRequest</code> is not set,
+set it to an empty object (to indicate that the exchange is not yet complete).
+                    </li>
+                    <li>
+Save the exchange (and call any non-blocking callback in the step).
+                    </li>
+                    <li>
+Return <var>response</var>.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+Set <var>response</var> to an empty object.
+                </li>
+                <li>
+If <var>step</var>.<code>verifiablePresentation</code> is set, set
+<var>response</var>.<code>verifiablePresentation</code> to a copy of it;
+otherwise set <var>response</var>.<code>verifiablePresentation</code> to a new,
+empty [=verifiable presentation=] (using [[VC-DATA-MODEL-2.0]] by default; a
+custom configuration MAY specify another version).
+                </li>
+              </ol>
+            </li>
+            <li>
+Perform every issue request (optionally in parallel), returning an error
+response to the client if any fails. Implementations MAY implement failure
+recovery or retry issue requests at their own discretion:
+              <ol class="algorithm">
+                <li>
+For each issue request where <code>result</code> is set to an exchange variable
+path or name, save the issued credential in the referenced exchange variable.
+                </li>
+                <li>
+For each issue request where <code>result</code> is not specified, save the
+issued credential in
+<var>response</var>.<code>verifiablePresentation</code> (for a VCDM
+presentation, append it to
+<code>response.verifiablePresentation.verifiableCredential</code>).
+                </li>
+              </ol>
+            </li>
+            <li>
+If <var>response</var>.<code>verifiablePresentation</code> is set and the step
+configuration indicates it should be signed, sign the presentation (for example,
+by using a VCALM holder instance's <code>/presentations</code> create endpoint).
+            </li>
+            <li>
+Call <code>isStepComplete</code>, passing <var>workflow</var>,
+<var>exchange</var>, <var>step</var>, <var>receivedPresentation</var>, and
+<var>receivedPresentationRequest</var>, to perform any protocol-specific
+behavior to determine if the step is complete. Set <var>stepComplete</var> to
+the result, defaulting to <code>true</code>.
+            </li>
+            <li>
+If <var>stepComplete</var> is <code>true</code>:
+              <ol class="algorithm">
+                <li>
+If <var>step</var>.<code>redirectUrl</code> is set:
+                  <ol class="algorithm">
+                    <li>
+If <var>response</var> is <code>null</code>, set it to an empty object.
+                    </li>
+                    <li>
+Set <var>response</var>.<code>redirectUrl</code> to
+<var>step</var>.<code>redirectUrl</code>.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+If <var>step</var>.<code>nextStep</code> is not set, set
+<var>exchange</var>.<code>state</code> to <code>complete</code>.
+                </li>
+                <li>
+Otherwise, delete
+<code>exchange.variables.results[step.nextStep]</code> if it exists, and set
+<var>exchange</var>.<code>step</code> to
+<var>step</var>.<code>nextStep</code>.
+                </li>
+              </ol>
+            </li>
+            <li>
+Save the exchange (and call any non-blocking callback in the step).
+            </li>
+            <li>
+If <var>exchange</var>.<code>state</code> is <code>complete</code>, return
+<var>response</var> if it is not <code>null</code>; otherwise return an empty
+object.
+            </li>
+            <li>
+Set <var>receivedPresentation</var> to <code>null</code> and continue the loop.
+            </li>
+          </ol>
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h3 id="workflow-processing-hooks">Protocol and implementation hooks</h3>
+
+      <p>
+The following hooks are intentionally underspecified so that implementations can
+bind the reference loop to a particular protocol or deployment:
+      </p>
+
+      <ul>
+        <li>
+<code>prepareStep</code> — optional protocol-specific preparation before
+validating client input for the current step.
+        </li>
+        <li>
+<code>validateReceivedPresentation</code> /
+<code>validateReceivedPresentationRequest</code> — validate a client-supplied
+presentation or presentation request against the current step.
+        </li>
+        <li>
+<code>inputRequired</code> — determine whether the loop must pause and return a
+response (typically including a presentation request) to the client.
+        </li>
+        <li>
+<code>createVerifiablePresentationRequest</code> — populate
+<code>response.verifiablePresentationRequest</code> from the step configuration
+and exchange variables.
+        </li>
+        <li>
+<code>isStepComplete</code> — determine whether the current step is finished and
+the exchange may advance to <code>nextStep</code> or <code>complete</code>.
+        </li>
+      </ul>
     </section>
   </section>
 


### PR DESCRIPTION
## Summary
- Adds an **informative** appendix documenting one reference algorithm for walking exchange/workflow steps until client input is needed or a response is ready ([#596](https://github.com/w3c/vcalm/issues/596)).
- Uses `ol.algorithm` style (same approach as Data Integrity / ECDSA cryptosuites and [#700](https://github.com/w3c/vcalm/pull/700)); includes protocol hooks (`prepareStep`, `inputRequired`, `isStepComplete`, etc.) so the loop stays agnostic to VC-API / OID4VP / OID4VCI / invite bindings.
- Cross-links from Workflows and Exchanges. Supersedes the `<pre>`-based approach in [#626](https://github.com/w3c/vcalm/pull/626).

**Stack:** Branched from [#700](https://github.com/w3c/vcalm/pull/700) (`OpSecId:docs/qbe-matching-and-json-pointers`). This PR currently targets `main`, so the GitHub diff may also show #700 commits until that PR merges—review the tip commit `docs: add informative reference workflow step processing appendix` for this change. After #700 merges, rebase this branch onto `main`.

Closes #596
Supersedes #626

## Test plan
- [ ] Respec preview: appendix marked informative; nested `ol.algorithm` numbering renders.
- [ ] Cross-link from Workflows and Exchanges resolves to the appendix.
- [ ] Spot-check algorithm steps against Dave’s text in #596 / prior #626 content.
- [ ] After #700 merges: rebase onto `main` and confirm the diff is appendix-only.


Made with [Cursor](https://cursor.com)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 11, 2026, 6:57 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=respec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fvcalm%2F461417f83a3ec134d083eafbabc239533f64bea7%2Findex.html%3FisPreview%3Dtrue)

**Error output:**

```
EISDIR: illegal operation on a directory, open 'uploads/uVOIek/'
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20w3c/vcalm%23701.)._

</details>
