### PR TITLE
Replace `trustedIssuer` with `acceptedIssuers` in VPR

### DIFF
--- a/index.html
+++ b/index.html
@@ -3580,8 +3580,8 @@ as described in Section [[[#participate-in-an-exchange]]].
             "studentId": ""
           },
         },
-        "trustedIssuer": [{
-          "issuer": "did:web:university.example"
+        "acceptedIssuers": [{
+          "id": "did:web:university.example"
         }]
       }
     }],


### PR DESCRIPTION
This PR addresses PR #703 by replacing all outstanding instances of "trustedIssuer" with "acceptedIssuers" in a VPR (currently only one example). We should merge this editorial fix ASAP.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kezike/vcalm/pull/704.html" title="Last updated on Aug 13, 2026, 9:55 AM UTC (52c7669)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vcalm/704/ac323b7...kezike:52c7669.html" title="Last updated on Aug 13, 2026, 9:55 AM UTC (52c7669)">Diff</a>