### PR TITLE
Updated respec-oas to version 1.0.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <script class="remove"
     src="https://www.w3.org/Tools/respec/respec-w3c"></script>
   <script class="remove"
-    src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-oas@1.0.1/dist/main.js"></script>
+    src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-oas@1.0.2/dist/main.js"></script>
   <script class="remove"
     src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-mermaid@1.3.0/dist/main.js"></script>
 


### PR DESCRIPTION
Updating the respec-oas version to v1.0.2

This fixes the render issue also found in the following PR: https://github.com/w3c/vcalm/pull/691
Also see issue: https://github.com/w3c/vcalm/issues/605

v1.0.2 of respec-oas now handles the previously unhandled case of ```allOf``` without a top-level ```type```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eric-schuh/vcalm/pull/706.html" title="Last updated on Aug 18, 2026, 5:21 PM UTC (010194d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vcalm/706/bb4c827...eric-schuh:010194d.html" title="Last updated on Aug 18, 2026, 5:21 PM UTC (010194d)">Diff</a>