### PR TITLE
Fix broken link for "transformation"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3842,7 +3842,7 @@ an `ecdsa-rdfc-2019`
 proof|proof=], can still present either. Other [=data integrity proof|proofs=],
 such as those that offer [=selective disclosure=] and / or [=unlinkable
 disclosure=] features require
-<a data-cite="?VC-DATA-INTEGRITY#transformation">transformation</a> (that is, a
+<a data-cite="?VC-DATA-INTEGRITY#transformations">transformation</a> (that is, a
 base proof is transformed to a derived proof plus a "reveal document") and,
 therefore, a wallet will not be able to [=presentation|present=] these [=data
 integrity proof|proofs=] unless the wallet has implemented the procedures for


### PR DESCRIPTION
Spec uses a plural ID.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vcalm/pull/708.html" title="Last updated on Aug 25, 2026, 10:32 AM UTC (b1571ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vcalm/708/24d8fc0...b1571ce.html" title="Last updated on Aug 25, 2026, 10:32 AM UTC (b1571ce)">Diff</a>