### PR TITLE
Add inline references and security/privacy tags to each threat.

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,6 +165,7 @@
     }]
   };
   </script>
+  <link rel="stylesheet" href="threat-model/threats/threat-model.css" />
   <style>
 code {
   color: rgb(199, 73, 0);
@@ -3700,6 +3701,282 @@ object MUST be set to `false`; if no errors are included, it MUST be set to
 
   </section>
 
+  <section class="appendix informative">
+    <h2>Threat Model</h2>
+
+    <p>
+This section details the general threat model for this specification
+including security considerations, privacy considerations, and market
+competition considerations. It makes reference to <a href="threat-model/index.html">a detailed threat model</a>, which was created
+based on a use case of a first responder onboarding themselves to a new incident. This use case was chosen because it could be simplified
+to detail the issuance of a [=verifiable credential=] for the particular incident, predicated on the [=verification=] of an existing emergency 
+responder credential. This enabled the data flow diagram in the threat model to detail both the [=verification=] and issuance steps, in the 
+same workflow.
+    </p>
+
+    <section>
+      <h3>Target Threats</h3>
+      <ol class="threat-toc">
+        <li value="1">
+          <a href="threat-model/index.html#t1-dos-attacks-against-public-coordinator-endpoints">
+DoS Attacks Against Public Coordinator Endpoints
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+Attackers perform a denial of service attack against one or more public [=coordinator=] endpoints,
+causing severe degradation of availability for legitimate clients.
+        </li>
+        <li value="4">
+          <a href="threat-model/index.html#t4-attacker-guesses-exchange-url">
+Attacker Guesses Exchange URL
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> <span class="threat-tag threat-tag-privacy">privacy</span> —
+Exchange URLs use predictable structures with discoverable workflow IDs, allowing automated scripts to only need to guess a particular
+exchange ID to effectively hijack a given exchange.
+        </li>
+        <li value="5">
+          <a href="threat-model/index.html#t5-issuance-information-stored-long-term">
+Issuance Information Stored Long-Term
+          </a>
+          <span class="threat-tag threat-tag-privacy">privacy</span> —
+Private processing logs, transaction metadata, or raw PII related to credential issuance are preserved by the issuer for longer than needed,
+creating an unintentional honey pot that could be a target for attackers.
+        </li>
+        <li value="6">
+          <a href="threat-model/index.html#t6-stolen-authorization-tokens">
+Stolen Authorization Tokens
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> <span class="threat-tag threat-tag-privacy">privacy</span> —
+A malicious entity exfiltrates authorization tokens for any involved process, using them to spoof authenticated clients.
+Depending on the affected process this could lead to any number of attacks such as: providing malicious interaction URLs,
+modifying workflows, changing issuance or verification policies, corrupting or spoofing credential statuses, etc.
+        </li>
+        <li value="17">
+          <a href="threat-model/index.html#t17-leaking-information-due-to-status-list-vc-updates">
+Leaking Information Due to Status List VC Updates
+          </a>
+          <span class="threat-tag threat-tag-privacy">privacy</span> —
+External observers consistently query status services to discover some information about the system issuing credentials,
+whether that be the rate at which they are issued, how many get issued, or in extreme cases for little used systems,
+what credential was issued to whom and when.
+        </li>
+        <li value="19">
+          <a href="threat-model/index.html#t19-interaction-urls-leak-personal-ips">
+Interaction URLs Leak Personal IPs
+          </a>
+          <span class="threat-tag threat-tag-privacy">privacy</span> —
+Direct network connections to interaction URLs expose user IP metrics and geographic data to backend servers during verification checks.
+        </li>
+        <li value="21">
+          <a href="threat-model/index.html#t21-dos-for-exchange-state-polling">
+DoS for Exchange State Polling
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+High frequencies of client state queries block active thread loops on internal database engines, reducing API capacity and crashing systems.
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h3>Implementation Threats</h3>
+      <ol class="threat-toc">
+        <li value="2">
+          <a href="threat-model/index.html#t2-attacker-bypasses-internal-security-to-issue-vc-to-attacker">
+Attacker Bypasses Internal Security to Issue VC to Attacker
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+An attacker bypasses internal architectural or network boundaries to directly invoke backend credential issuance services,
+forging or granting unauthorized credentials to themselves.
+        </li>
+        <li value="3">
+          <a href="threat-model/index.html#t3-interaction-urls-with-origins-that-do-not-match-coordinator-origin">
+Interaction URLs with Origins That Do Not Match Coordinator Origin
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> <span class="threat-tag threat-tag-privacy">privacy</span> —
+A coordinator provides an interaction URL whose web origin deviates from the coordinator host origin.
+In a non-malicious application: at best, this goes unnoticed by the user; at worst, it causes confusion for the user when they see
+they are being redirected away from the website they thought they were on or going to, possibly leading them to cancel the interaction.
+With a malicious actor, this would enable cross-site tracking or session hijacking exploits.
+        </li>
+        <li value="9">
+          <a href="threat-model/index.html#t9-wrong-authorization-scope">
+Wrong Authorization Scope
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+Access tokens contain overly wide authorization permission settings,
+allowing a compromised unprivileged sub-component to invoke unintended functions.
+        </li>
+        <li value="14">
+          <a href="threat-model/index.html#t14-reusing-presentation-challenges-vs-allowing-network-resiliency">
+Reusing Presentation Challenges vs Allowing Network Resiliency
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+Reusing cryptographic challenge tokens to bridge unreliable mobile connections
+allows network sniffers to capture presentation payloads and execute replay attacks.
+        </li>
+        <li value="15">
+          <a href="threat-model/index.html#t15-invalid-assignment-or-overallocation-of-status-list-indexes">
+Invalid Assignment or Overallocation of Status List Indexes
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+The issuer service incorrectly assigns multiple issued credentials to the same index in the status list, or assigns a credential to an index that is not in the list, leading to either incorrect or missing verification results.
+        </li>
+        <li value="16">
+          <a href="threat-model/index.html#t16-too-many-status-lists-created-for-too-small-of-a-population">
+Too Many Status Lists Created for Too Small of a Population
+          </a>
+          <span class="threat-tag threat-tag-privacy">privacy</span> —
+Deployed status lists map to tightly scoped population pools, reducing user tracking privacy and enabling passive metadata linkage.
+        </li>
+        <li value="18">
+          <a href="threat-model/index.html#t18-protocol-confusion-when-multiple-protocol-options-are-available">
+Protocol Confusion When Multiple Protocol Options Are Available
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+A mixed-profile deployment environment allows an adversary to intentionally submit legacy or insecure alternative versions of requests, tricking the coordinator into lowering validation rules.
+        </li>
+        <li value="20">
+          <a href="threat-model/index.html#t20-exchange-state-leaked-to-coordinator-frontend">
+Exchange State Leaked to Coordinator Frontend
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+Granular internal processing states bleed out into frontend responses, revealing sensitive system execution parameters to local client scraping or cross-site threats.
+        </li>
+        <li value="22">
+          <a href="threat-model/index.html#t22-misconfigured-issuer-instance">
+Misconfigured Issuer Instance
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+An issuer administrator misconfigures some aspect of the issuance software, whether that be the coordinator service or the workflow service related to issuing credentials, leading to false issuance or an incorrect rejection of an issuance request.
+        </li>
+        <li value="23">
+          <a href="threat-model/index.html#t23-misconfigured-status-instance">
+Misconfigured Status Instance
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+An incorrectly deployed status service allows unauthorized users to write unvetted status indicators or read metrics without proper authorization checks.
+        </li>
+        <li value="24">
+          <a href="threat-model/index.html#t24-misconfigured-verifier-instance">
+Misconfigured Verifier Instance
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+A verifier administrator misconfigures some aspect of the verification software, whether that be the coordinator service or the workflow service related to verifying credentials, leading to inaccurate or wrong verifications.
+        </li>
+        <li value="25">
+          <a href="threat-model/index.html#t25-failure-to-validate-verifier-results-and-semantic-contexts">
+Failure to Validate Verifier Results and Semantic Contexts
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+Verification components fail to parse nested semantic outcomes (like specialized `revoked=true` fields) or blindly fetch untrusted external JSON-LD schemas, causing unexpected remote execution patterns.
+        </li>
+        <li value="26">
+          <a href="threat-model/index.html#t26-misconfigured-workflow-instance">
+Misconfigured Workflow Instance
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+Flaws in one or more workflows allow a user client to bypass prerequisites, jumping directly into incorrect success or failure states.
+        </li>
+        <li value="27">
+          <a href="threat-model/index.html#t27-workflow-variables-allow-workflow-template-to-be-misused">
+Workflow Variables Allow Workflow Template to be Misused
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+Workflow variable options expose unintended workflow paths allowing misused workflows or malicious actors to achieve unintended outcomes for the workflow.
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h3>External Threats</h3>
+      <ol class="threat-toc">
+        <li value="8">
+          <a href="threat-model/index.html#t8-issuer-authentication-leads-to-incorrect-vc-being-issued-to-attacker">
+Issuer Authentication Leads to Incorrect VC Being Issued to Attacker
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+Gaps or vulnerabilities within the initial enrollment or proofing layer
+let an attacker successfully spoof an identity verification checkpoint,
+resulting in a legitimate VC mapped to an illegitimate owner.
+        </li>
+        <li value="10">
+          <a href="threat-model/index.html#t10-interaction-url-leads-to-attacker-controlled-website">
+Interaction URL Leads to Attacker-Controlled Website
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> <span class="threat-tag threat-tag-privacy">privacy</span> —
+Malicious interaction URL directs users onto phishing, scam, or otherwise unwanted sites built to harvest private data.
+        </li>
+        <li value="11">
+          <a href="threat-model/index.html#t11-holder-shares-credential-with-attacker-for-the-purposes-of-replaying-the-credential">
+Holder Shares Credential with Attacker for the Purposes of Replaying the Credential
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> <span class="threat-tag threat-tag-privacy">privacy</span> —
+Social engineering tricks a [=holder=] into presenting an active Verifiable Credential to an adversarial [=verifier=] instance, which then replays the static payload string to a real provider.
+        </li>
+        <li value="12">
+          <a href="threat-model/index.html#t12-use-of-protocol-to-centralize-digital-credentials-ecosystem-and-lockout-competition">
+Use of Protocol to Centralize Digital Credentials Ecosystem and Lockout Competition
+          </a>
+          <span class="threat-tag">market competition</span> —
+Market-dominant platforms choose to only offer their chosen protocol for credential interactions, leading to many holder implementations omitting other protocols.
+        </li>
+        <li value="13">
+          <a href="threat-model/index.html#t13-interaction-url-read-from-qr-code-is-opened-by-unexpected-or-malicious-application">
+Interaction URL Read from QR Code is Opened by Unexpected or Malicious Application
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> <span class="threat-tag threat-tag-privacy">privacy</span> —
+A rogue app present on the [=holder's=] device registers matching protocol handlers, capturing deep link output from scanned QR strings, and takes control of the interaction.
+        </li>
+        <li value="29">
+          <a href="threat-model/index.html#t29-ecosystem-gatekeeping-in-the-name-of-security-or-privacy">
+Ecosystem Gatekeeping in the Name of Security or Privacy
+          </a>
+          <span class="threat-tag">market competition</span> —
+Primary ecosystem actors choose to restrict their support of particular protocols or data formats in the name of security or privacy whereas in reality they are trying to push the ecosystem to adopt their solution.
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h3>Dependency Threats</h3>
+      <ol class="threat-toc">
+        <li value="7">
+          <a href="threat-model/index.html#t7-revocation-list-unavailable">
+Revocation List Unavailable
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+Whether because an issuing business goes insolvent, permanently shuts down its operations, or simply decides to stop supporting a system, the status service becomes unreachable, breaking verification logic across the ecosystem.
+        </li>
+        <li value="28">
+          <a href="threat-model/index.html#t28-callback-urls-during-workflows-slow-to-respond">
+Callback URLs During Workflows Slow to Respond
+          </a>
+          <span class="threat-tag threat-tag-security">security</span> —
+Downstream consumer webhooks or internal endpoints process calls slowly, filling internal worker pools and triggering cascading system timeouts.
+        </li>
+      </ol>
+    </section>
+
+    <section class="notoc">
+      <h3>Security Considerations</h4>
+      <p>
+  W3C is migrating to a holistic threat modelling approach and is in the process
+  of deprecating the Security Considerations sections in new specifications.
+  Please refer to Appendix [[[#threat-model]]] for documentation related to
+  security considerations.
+      </p>
+    </section>
+
+    <section class="notoc">
+      <h3>Privacy Considerations</h4>
+      <p>
+  W3C is migrating to a holistic threat modelling approach and is in the process
+  of deprecating the Privacy Considerations sections in new specifications. Please
+  refer to Appendix [[[#threat-model]]] for documentation related to privacy
+  considerations.
+      </p>
+    </section>
+  </section>
+
   <section class="appendix">
     <h2>Privacy Considerations</h2>
     <p>
@@ -3979,17 +4256,6 @@ OWASP Secure Coding Practices Checklist</a> and the
 <a href="https://owasp.org/www-project-web-security-testing-guide/">
 OWASP Web Security Testing Guide</a> can help reduce the chance of insecure
 implementations.
-      </p>
-    </section>
-
-    <section>
-      <h3>Threat Model</h3>
-      <p>
-        A <a href="threat-model/index.html">threat model for the VCALM specification</a> has been created
-        based on a use case of a first responder onboarding themselves to a new incident. This use case was chosen because it could be simplified
-        to detail the issuance of a [=verifiable credential=] for the particular incident, predicated on the [=verification=] of an existing emergency 
-        responder credential. This enabled the data flow diagram in the threat model to detail both the [=verification=] and issuance steps, in the 
-        same workflow. 
       </p>
     </section>
 

--- a/threat-model/index.html
+++ b/threat-model/index.html
@@ -98,7 +98,7 @@
   <script src="threats/t11-holder-shares-credential-with-attacker-for-the-purposes-of-replaying-the-credential.js"></script>
   <script src="threats/t12-use-of-protocol-to-centralize-digital-credentials-ecosystem-and-lockout-competition.js"></script>
   <script src="threats/t13-interaction-url-read-from-qr-code-is-opened-by-unexpected-or-malicious-application.js"></script>
-  <script src="threats/t14-presentation-challenge-reuse-vs-allowing-network-resiliency.js"></script>
+  <script src="threats/t14-reusing-presentation-challenges-vs-allowing-network-resiliency.js"></script>
   <script src="threats/t15-invalid-assignment-or-overallocation-of-status-list-indexes.js"></script>
   <script src="threats/t16-too-many-status-lists-created-for-too-small-of-a-population.js"></script>
   <script src="threats/t17-leaking-information-due-to-status-list-vc-updates.js"></script>

--- a/threat-model/threats/t1-dos-attacks-against-public-coordinator-endpoints.js
+++ b/threat-model/threats/t1-dos-attacks-against-public-coordinator-endpoints.js
@@ -8,6 +8,7 @@
             { id: "R2", name: "Event-Driven Architecture and Async Message Queues", type: "Reduce", desc: "Decouple direct synchronous processing loops by routing transactional requests into asynchronous, managed worker queues to shield critical database threads from flooding." }
         ],
         elements: ["P4"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Denial of Service"
     };

--- a/threat-model/threats/t10-interaction-url-leads-to-attacker-controlled-website.js
+++ b/threat-model/threats/t10-interaction-url-leads-to-attacker-controlled-website.js
@@ -7,6 +7,7 @@
             { id: "R5", name: "Interaction URL Origin Validation and Elevation", type: "Reduce", desc: "Any software that is expecting to consume an interaction URL should carefully consider their policies around interaction URL origins not matching. Implementers should consider overriding any user settings about automatically engaging with interaction URLs in the case of an origin mismatch and elevate the decision about the engagement to the user, or may choose to simply block such interactions from occurring." }
         ],
         elements: ["D2", "P4", "P2", "F3", "F4", "F5", "P1"],
+        tags: ["security", "privacy"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Spoofing"
     };

--- a/threat-model/threats/t11-holder-shares-credential-with-attacker-for-the-purposes-of-replaying-the-credential.js
+++ b/threat-model/threats/t11-holder-shares-credential-with-attacker-for-the-purposes-of-replaying-the-credential.js
@@ -2,12 +2,13 @@
     var threat = {
         id: "T11",
         name: "Holder Shares Credential with Attacker for the Purposes of Replaying the Credential",
-        desc: "Social engineering tricks a user into presenting an active Verifiable Credential to an adversarial verifier instance, which then replays the static payload string to a real provider.",
+        desc: "Social engineering tricks a [=holder=] into presenting an active Verifiable Credential to an adversarial [=verifier=] instance, which then replays the static payload string to a real provider.",
         response: [
-            { id: "R13", name: "Asymmetric Cryptographic Holder Binding", type: "Reduce", desc: "Require cryptographic verification proofs during individual presentations, rendering useless any static transaction copies that don't hold the operational private keys." },
+            { id: "R13", name: "Asymmetric Cryptographic Holder Binding", type: "Reduce", desc: "Require cryptographic verification proofs during individual presentations, rendering useless any static transaction copies that don't hold the proper signature based on the bound key (DID Authentication)." },
             { id: "R14", name: "Domain-Bound Ephemeral Verification Challenges", type: "Reduce", desc: "Embed unique, strictly single-use, cryptographic nonces (random numbers, each used once), combined with pins to the target audience domain, inside every transaction request." }
         ],
         elements: ["F12", "P5", "F13", "P6"],
+        tags: ["security", "privacy"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Spoofing"
     };

--- a/threat-model/threats/t12-use-of-protocol-to-centralize-digital-credentials-ecosystem-and-lockout-competition.js
+++ b/threat-model/threats/t12-use-of-protocol-to-centralize-digital-credentials-ecosystem-and-lockout-competition.js
@@ -5,6 +5,7 @@
         desc: "Market-dominant platforms choose to only offer their chosen protocol for credential interactions, leading to many holder implementations omitting other protocols.",
         response: [],
         elements: ["D4", "F6", "P4", "P1"],
+        tags: ["market competition"],
         taxonomyName: "TODO",
         taxonomyClass: "TODO"
     };

--- a/threat-model/threats/t13-interaction-url-read-from-qr-code-is-opened-by-unexpected-or-malicious-application.js
+++ b/threat-model/threats/t13-interaction-url-read-from-qr-code-is-opened-by-unexpected-or-malicious-application.js
@@ -1,14 +1,15 @@
 (function () {
     var threat = {
         id: "T13",
-        name: "Interaction URL read from QR Code is opened by unexpected or malicious application",
-        desc: "A rogue app present on the holder’s device registers matching protocol handlers, capturing deep link output from scanned QR strings, and takes control of the interaction.",
+        name: "Interaction URL Read from QR Code is Opened by Unexpected or Malicious Application",
+        desc: "A rogue app present on the [=holder's=] device registers matching protocol handlers, capturing deep link output from scanned QR strings, and takes control of the interaction.",
         response: [
             { id: "R12", name: "Cryptographic Pinning of Application Links", type: "Eliminate", desc: "Holder coordinator processes should run deep routing configurations (Universal Links on iOS, or Android App Links) to stop link interceptions." }
         ],
         elements: ["D2", "F3", "F4", "F5", "P1"],
+        tags: ["security", "privacy"],
         taxonomyName: "STRIDE",
-        taxonomyClass: "Tampering"
+        taxonomyClass: "Spoofing"
     };
     window.ThreatModel.register(threat);
 })();

--- a/threat-model/threats/t14-reusing-presentation-challenges-vs-allowing-network-resiliency.js
+++ b/threat-model/threats/t14-reusing-presentation-challenges-vs-allowing-network-resiliency.js
@@ -7,6 +7,7 @@
             { id: "R14", name: "Domain-Bound Verification Challenges", type: "Reduce", desc: "Embed unique, strictly single-use, cryptographic challenges, combined with pins to the target audience domain(s) inside presentation request and response objects." }
         ],
         elements: ["P1", "P5", "F7", "F8", "F12", "F19"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Spoofing"
     };

--- a/threat-model/threats/t15-invalid-assignment-or-overallocation-of-status-list-indexes.js
+++ b/threat-model/threats/t15-invalid-assignment-or-overallocation-of-status-list-indexes.js
@@ -5,11 +5,12 @@
         desc: "The issuer service incorrectly assigns multiple issued credentials to the same index in the status list, or assigns a credential to an index that is not in the list, leading to either incorrect or missing verification results.",
         response: [
             { id: "R15", name: "Status List Assignment Testing", type: "Reduce", desc: "Use robust testing to ensure that issuer software does not assign duplicate indexes from the status list and properly provisions new lists when existing ones are full." },
-            { id: "R25", name: "Verifier Acceptance of Unavailable Status Service", type: "Accept", desc: "Some businesses or services will not care that some or all of their issued credentials are usable indefinitely, and some may actively choose to make this service unavailable. Verifier software, as well as any process handling business logic related to verification should handle such cases and not rely on status services being always available." }
+            { id: "R25", name: "Verifier Acceptance of Unavailable Status Service", type: "Accept", desc: "Some businesses or services will not care that some or all of their issued credentials are usable indefinitely, and some may actively choose to make this service unavailable. Verifier software, as well as any process handling business logic related to verification should handle such cases and not rely on status services always being available." }
         ],
         elements: ["P7", "F17", "P8", "P6", "F14", "P9"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
-        taxonomyClass: "Information Disclosure"
+        taxonomyClass: "Tampering"
     };
     window.ThreatModel.register(threat);
 })();

--- a/threat-model/threats/t16-too-many-status-lists-created-for-too-small-of-a-population.js
+++ b/threat-model/threats/t16-too-many-status-lists-created-for-too-small-of-a-population.js
@@ -7,6 +7,7 @@
             { id: "R16", name: "Privacy-Preserving, Minimum-Sizing Constraints", type: "Reduce", desc: "Enforce systemic validation requirements to ensure that all public status lists scale above the minimum index counts needed to maintain k-anonymity privacy protections." },
         ],
         elements: ["P8", "P9", "P7", "F17", "F14"],
+        tags: ["privacy"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Information Disclosure"
     };

--- a/threat-model/threats/t17-leaking-information-due-to-status-list-vc-updates.js
+++ b/threat-model/threats/t17-leaking-information-due-to-status-list-vc-updates.js
@@ -7,6 +7,7 @@
             { id: "R17", name: "Deterministic Batching Schedules and State Padding", type: "Reduce", desc: "Push state modifications to public status lists, on strict, standardized, scheduled intervals, and fill unallocated tracking bits with random placeholder configurations, instead of streaming real-time alerts." }
         ],
         elements: ["E1", "C5", "P7", "F17", "P8", "F6", "F14", "P9"],
+        tags: ["privacy"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Information Disclosure"
     };

--- a/threat-model/threats/t18-protocol-confusion-when-multiple-protocol-options-are-available.js
+++ b/threat-model/threats/t18-protocol-confusion-when-multiple-protocol-options-are-available.js
@@ -7,6 +7,7 @@
             { id: "R18", name: "Deprecating Interfaces and Disabling Secure Fallbacks", type: "Reduce", desc: "Hardcode execution restrictions that block processing steps for legacy or unvetted fallback patterns, enforcing a strict validation policy for protocol specifications." }
         ],
         elements: ["D4", "P4", "F6", "P1"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Tampering"
     };

--- a/threat-model/threats/t19-interaction-urls-leak-personal-ips.js
+++ b/threat-model/threats/t19-interaction-urls-leak-personal-ips.js
@@ -3,8 +3,11 @@
         id: "T19",
         name: "Interaction URLs Leak Personal IPs",
         desc: "Direct network connections to interaction URLs expose user IP metrics and geographic data to backend servers during verification checks.",
-        response: ["Use interaction URL proxies, mixnets, or interaction URL locations where the population using the interaction URLs is large and diverse."],
+        response: [
+            { id: "R22", name: "URL Proxies and Mixnets", type: "Reduce", desc: "Use interaction URL proxies, mixnets, or interaction URL locations where the population using the interaction URLs is large and diverse." }
+        ],
         elements: ["E1", "F6", "P4"],
+        tags: ["privacy"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Information Disclosure"
     };

--- a/threat-model/threats/t2-attacker-bypasses-internal-security-to-issue-vc-to-attacker.js
+++ b/threat-model/threats/t2-attacker-bypasses-internal-security-to-issue-vc-to-attacker.js
@@ -8,6 +8,7 @@
             { id: "R4", name: "Granular Privilege Scoping", type: "Reduce", desc: "Enforce explicit, fine-grained access control scopes combined with server-side validation rules to verify the identity and permission layout of any invoking resource." }
         ],
         elements: ["P7", "F16"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Elevation of Privilege, Spoofing"
     };

--- a/threat-model/threats/t2-attacker-bypasses-internal-security-to-issue-vc-to-attacker.js
+++ b/threat-model/threats/t2-attacker-bypasses-internal-security-to-issue-vc-to-attacker.js
@@ -10,7 +10,7 @@
         elements: ["P7", "F16"],
         tags: ["security"],
         taxonomyName: "STRIDE",
-        taxonomyClass: "Elevation of Privilege, Spoofing"
+        taxonomyClass: "Elevation of Privilege"
     };
     window.ThreatModel.register(threat);
 })();

--- a/threat-model/threats/t20-exchange-state-leaked-to-coordinator-frontend.js
+++ b/threat-model/threats/t20-exchange-state-leaked-to-coordinator-frontend.js
@@ -7,6 +7,7 @@
             { id: "R19", name: "Strict Filtering of Exchange States", type: "Reduce", desc: "Enforce explicit layers in the system API boundaries to isolate backend state-tracking structures from public consumer schemas." }
         ],
         elements: ["P4", "F23", "P5"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Information Disclosure"
     };

--- a/threat-model/threats/t21-dos-for-exchange-state-polling.js
+++ b/threat-model/threats/t21-dos-for-exchange-state-polling.js
@@ -7,6 +7,7 @@
             { id: "R1", name: "Volumetric Rate Limiting and WAF Architecture", type: "Reduce", desc: "Deploy an enterprise Web Application Firewall (WAF) coupled with strict Internet Protocol (IP) and token-based rate limiting thresholds at the Application Programming Interface (API) Gateway to drop volumetric attack traffic." }
         ],
         elements: ["P4", "F23", "P5"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Denial of Service"
     };

--- a/threat-model/threats/t22-misconfigured-issuer-instance.js
+++ b/threat-model/threats/t22-misconfigured-issuer-instance.js
@@ -8,6 +8,7 @@
             { id: "R27", name: "Robust Testing", type: "Reduce", desc: "Each workflow and individual endpoint on all processes should have robust testing to ensure expected results." }
         ],
         elements: ["P4", "P5", "P7"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Elevation of Privilege"
     };

--- a/threat-model/threats/t23-misconfigured-status-instance.js
+++ b/threat-model/threats/t23-misconfigured-status-instance.js
@@ -6,11 +6,13 @@
         response: [
             { id: "R20", name: "Code Validation", type: "Reduce", desc: "Mandate that security configuration properties pass automated vulnerability configuration scanning checks before hitting production environments." },
             { id: "R21", name: "Cryptographically Bound Registry Permissions", type: "Reduce", desc: "Hardcode security dependencies requiring matching cryptographic signature assertions to stop unauthorized status modifications." },
+            { id: "R26", name: "Misconfigurations Happen", type: "Accept", desc: "Despite best efforts, people make mistakes and misconfigurations will happen." },
             { id: "R27", name: "Robust Testing", type: "Reduce", desc: "Each workflow and individual endpoint on all processes should have robust testing to ensure expected results." }
         ],
         elements: ["P7", "F17", "P8", "P6", "F14", "P9"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
-        taxonomyClass: "Tampering"
+        taxonomyClass: "Elevation of Privilege"
     };
     window.ThreatModel.register(threat);
 })();

--- a/threat-model/threats/t24-misconfigured-verifier-instance.js
+++ b/threat-model/threats/t24-misconfigured-verifier-instance.js
@@ -8,6 +8,7 @@
             { id: "R27", name: "Robust Testing", type: "Reduce", desc: "Each workflow and individual endpoint on all processes should have robust testing to ensure expected results." }
         ],
         elements: ["P4", "P5", "P7"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Elevation of Privilege"
     };

--- a/threat-model/threats/t25-failure-to-validate-verifier-results-and-semantic-contexts.js
+++ b/threat-model/threats/t25-failure-to-validate-verifier-results-and-semantic-contexts.js
@@ -2,11 +2,12 @@
     var threat = {
         id: "T25",
         name: "Failure to Validate Verifier Results and Semantic Contexts",
-        desc: "Verification components fail to parse nested semantic outcomes (like specialized \"revoked=true\" fields) or blindly fetch untrusted external JSON-LD schemas, causing unexpected remote execution patterns.",
+        desc: "Verification components fail to parse nested semantic outcomes (like specialized `revoked=true` fields) or blindly fetch untrusted external JSON-LD schemas, causing unexpected remote execution patterns.",
         response: [],
         elements: ["P5", "F13", "P6", "F14", "P9", "F15"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
-        taxonomyClass: "Spoofing"
+        taxonomyClass: "Elevation of Privilege"
     };
     window.ThreatModel.register(threat);
 })();

--- a/threat-model/threats/t26-misconfigured-workflow-instance.js
+++ b/threat-model/threats/t26-misconfigured-workflow-instance.js
@@ -4,13 +4,13 @@
         name: "Misconfigured Workflow Instance",
         desc: "Flaws in one or more workflows allow a user client to bypass prerequisites, jumping directly into incorrect success or failure states.",
         response: [
-            { id: "R26", name: "Misconfigurations Happen", type: "Accept", desc: "Despite best efforts, people make mistakes and misconfigurations will happen.",
-              id: "R26.1", name: "Audit for Quality", type: "Reduce", desc: "<a>Issuers</a> implement audit processes to perform regular quality assurance.",
-              id: "R26.2", name: "Undo by Revocation", type: "Accept and Transfer", desc: "When misconfiguration happens, <a>Issuers</a> revoke credentials.",
-             },
-            { id: "R27", name: "Robust Testing", type: "Reduce", desc: "Each workflow and individual endpoint on all processes should have robust testing to ensure expected results." }
+            { id: "R26", name: "Misconfigurations Happen", type: "Accept", desc: "Despite best efforts, people make mistakes and misconfigurations will happen." },
+            { id: "R27", name: "Robust Testing", type: "Reduce", desc: "Each workflow and individual endpoint on all processes should have robust testing to ensure expected results." },
+            { id: "R28", name: "Audit for Quality", type: "Reduce", desc: "<a>Issuers</a> implement audit processes to perform regular quality assurance." },
+            { id: "R29", name: "Undo by Revocation", type: "Accept and Transfer", desc: "When misconfiguration happens, <a>Issuers</a> revoke credentials." }
         ],
         elements: ["P1", "F8", "P5", "F12", "F9"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Elevation of Privilege"
     };

--- a/threat-model/threats/t27-workflow-variables-allow-workflow-template-to-be-misused.js
+++ b/threat-model/threats/t27-workflow-variables-allow-workflow-template-to-be-misused.js
@@ -7,8 +7,9 @@
             { id: "R27", name: "Robust Testing", type: "Reduce", desc: "Each workflow and individual endpoint on all processes should have robust testing to ensure expected results." }
         ],
         elements: ["P1", "F8", "P5", "F12", "F9"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
-        taxonomyClass: "Tampering"
+        taxonomyClass: "Information Disclosure"
     };
     window.ThreatModel.register(threat);
 })();

--- a/threat-model/threats/t28-callback-urls-during-workflows-slow-to-respond.js
+++ b/threat-model/threats/t28-callback-urls-during-workflows-slow-to-respond.js
@@ -5,6 +5,7 @@
         desc: "Downstream consumer webhooks or internal endpoints process calls slowly, filling internal worker pools and triggering cascading system timeouts.",
         response: [],
         elements: ["P5", "F7", "F12", "F18", "F15", "F2", "P1", "P4", "P7", "P6"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Denial of Service"
     };

--- a/threat-model/threats/t29-ecosystem-gatekeeping-in-the-name-of-security-or-privacy.js
+++ b/threat-model/threats/t29-ecosystem-gatekeeping-in-the-name-of-security-or-privacy.js
@@ -5,6 +5,7 @@
         desc: "Primary ecosystem actors choose to restrict their support of particular protocols or data formats in the name of security or privacy whereas in reality they are trying to push the ecosystem to adopt their solution.",
         response: [],
         elements: ["E1"],
+        tags: ["market competition"],
         taxonomyName: "TODO",
         taxonomyClass: "TODO"
     };

--- a/threat-model/threats/t3-interaction-urls-with-origins-that-do-not-match-coordinator-origin.js
+++ b/threat-model/threats/t3-interaction-urls-with-origins-that-do-not-match-coordinator-origin.js
@@ -2,11 +2,12 @@
     var threat = {
         id: "T3",
         name: "Interaction URLs with Origins That Do Not Match Coordinator Origin",
-        desc: "A coordinator provides an interaction URL whose web origin deviates from the coordinator host origin. At best in a non-malicious application, this goes unnoticed by the user; at worse, it causes a user confusion when they see they are being redirected away from the website they thought they were on or going to, possibly leading them to cancel the interaction. With a malicious actor, this would enable cross-site tracking or session hijacking exploits.",
+        desc: "A coordinator provides an interaction URL whose web origin deviates from the coordinator host origin. In a non-malicious application: at best, this goes unnoticed by the user; at worst, it causes confusion for the user when they see they are being redirected away from the website they thought they were on or going to, possibly leading them to cancel the interaction. With a malicious actor, this would enable cross-site tracking or session hijacking exploits.",
         response: [
             { id: "R5", name: "Interaction URL Origin Validation and Elevation", type: "Reduce", desc: "Any software that is expecting to consume an interaction URL should carefully consider their policies around interaction URL origins not matching. Implementers should consider overriding any user settings about automatically engaging with interaction URLs in the case of an origin mismatch and elevate the decision about the engagement to the user, and can choose to simply block such interactions from occurring." }
         ],
         elements: ["P2", "P4", "F3", "D2"],
+        tags: ["security", "privacy"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Tampering"
     };

--- a/threat-model/threats/t4-attacker-guesses-exchange-url.js
+++ b/threat-model/threats/t4-attacker-guesses-exchange-url.js
@@ -8,6 +8,7 @@
             { id: "R7", name: "Use Reasonable Time-to-Live", type: "Reduce", desc: "Assign the appropriate lifespan to a particular exchange URL for the given use case." }
         ],
         elements: ["P5", "F7", "F12", "D9"],
+        tags: ["security", "privacy"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Spoofing"
     };

--- a/threat-model/threats/t5-issuance-information-stored-long-term.js
+++ b/threat-model/threats/t5-issuance-information-stored-long-term.js
@@ -9,6 +9,7 @@
             { id: "R24", name: "Secure Data Vaults", type: "Transfer", desc: "If some user data needs to be saved for an appropriate legal reason, ensure that the data is not stored with the primary issuance software and has minimal or no publicly accessible endpoints." }
         ],
         elements: ["P5", "P7"],
+        tags: ["privacy"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Information Disclosure"
     };

--- a/threat-model/threats/t6-stolen-authorization-tokens.js
+++ b/threat-model/threats/t6-stolen-authorization-tokens.js
@@ -8,6 +8,7 @@
             { id: "R23", name: "Maintain Modern Operational Security", type: "Reduce", desc: "Ensure systems that have a reason to store any form of user related data have the most up to date security and surrounding policy practices." }
         ],
         elements: ["P1", "P3", "P4", "P5", "P6", "P7", "P8", "P9"],
+        tags: ["security", "privacy"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Spoofing"
     };

--- a/threat-model/threats/t7-revocation-list-unavailable.js
+++ b/threat-model/threats/t7-revocation-list-unavailable.js
@@ -5,9 +5,10 @@
         desc: "Whether because an issuing business goes insolvent, permanently shuts down its operations, or simply decides to stop supporting a system, the status service becomes unreachable, breaking verification logic across the ecosystem.",
         response: [
             { id: "R10", name: "Decentralized Content-Addressable Status Frameworks", type: "Transfer", desc: "Transition status infrastructure from synchronous, live-lookup services to signed, content-addressable registries that can be cached on decentralized storage systems like the InterPlanetary File System (IPFS) or Content Delivery Networks (CDNs)." },
-            { id: "R25", name: "Verifier Acceptance of Unavailable Status Service", type: "Accept", desc: "Not all businesses or services will care if their issued credentials are usable indefinitely, and some may actively choose to make this service unavailable. Verifier software, along with any process handling business logic related to verification, should handle this case and not rely on status services being always available." }
+            { id: "R25", name: "Verifier Acceptance of Unavailable Status Service", type: "Accept", desc: "Not all businesses or services will care if their issued credentials are usable indefinitely, and some may actively choose to make this service unavailable. Verifier software, along with any process handling business logic related to verification, should handle this case and not rely on status services always being available." }
         ],
         elements: ["P6", "F14", "P1", "P2"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Denial of Service"
     };

--- a/threat-model/threats/t8-issuer-authentication-leads-to-incorrect-vc-being-issued-to-attacker.js
+++ b/threat-model/threats/t8-issuer-authentication-leads-to-incorrect-vc-being-issued-to-attacker.js
@@ -7,6 +7,7 @@
             { id: "R11", name: "Use Case Appropriate Identity Proofing Integration", type: "Reduce", desc: "Implementers should consider their use case carefully and implement identity assurance that fits the potential harms that may come from this kind of spoofing attack without unduly requiring the revelation of user PII beyond what is reasonable for the use case." }
         ],
         elements: [],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Spoofing"
     };

--- a/threat-model/threats/t9-wrong-authorization-scope.js
+++ b/threat-model/threats/t9-wrong-authorization-scope.js
@@ -7,6 +7,7 @@
             { id: "R4", name: "Granular Least Privilege Scoping", type: "Reduce", desc: "Enforce explicit, fine-grained access control scopes combined with server-side validation rules to verify the identity and permission layout of any invoking resource via object capabilities." }
         ],
         elements: ["P3", "P5", "P6", "P7", "P8", "P9"],
+        tags: ["security"],
         taxonomyName: "STRIDE",
         taxonomyClass: "Elevation of Privilege"
     };

--- a/threat-model/threats/threat-model.css
+++ b/threat-model/threats/threat-model.css
@@ -135,18 +135,19 @@ section.threatDetail {
 }
 
 span.threat-tag {
-    border-radius: 4px;
+    border-radius: 8px;
     padding: 2px 5px;
     color: white;
     margin: 0px 2px;
-    font-weight: 100;
-    background-color: black;
+    font-weight: normal;
+    color: black;
+    background-color: #a9c9e8;
 }
 
 span.threat-tag.threat-tag-security {
-    background-color: red;
+    background-color: #f4a7a3;
 }
 
 span.threat-tag.threat-tag-privacy {
-    background-color: blue;
+    background-color: #f8c49a;
 }


### PR DESCRIPTION
This PR continues preparation for horizontal review for candidate recommendation by adding inline references to each threat from the main spec page, adding security and privacy tags, and advising reviewers to refer to W3C's latest guidance to spec authors on utilizing a unified threat model instead of “Privacy Considerations” and “Security Considerations” sections.

**IMPORTANT TODO**: We need to decide what to do about the existing “Privacy Considerations” and “Security Considerations” sections. I have temporarily kept them in because they contain thoughtful guidance that was carefully drafted in the past for reviewers to consider. For example, I know that the _Secure Coding Practices_ section was added in response to an issue warning implementers not to grant frontend coordinators access to backend secrets. Looking for guidance on whether to include the guidance from this section into another section of the spec (e.g., an appendix) or retire it altogether if we find that it is now redundant with the threat model or existing sections/appendices. CC @msporny @eric-schuh @jandrieu 

Here is a detailed breakdown of all the changes featured in this PR:

1. Add privacy/security/market comp tag(s) to each threat.
2. Add inline references to each threat from main spec page.
3. Add language in “Privacy Considerations” and “Security Considerations” sections to advise migration to new threat model design championed by W3C.
4. Update threat model style to match other specs. 
5. Fix T19 response format.
6. Fix T14 anchor tag.
7. Change taxonomy class of T15 from “Information Disclosure” to “Tampering”.
8. Change taxonomy class of T23 from “Tampering” to “Elevation of Privilege”.
9. Add “Misconfigurations Happens” to response list of T23.
10. Change taxonomy class of T25 from “Spoofing” to “Elevation of Privilege” (we plan to split up this threat because it covers multiple issues that have different STRIDE implications).
11. Fix T26 response format.
12. Rename R26.1 and R26.2 to R28 and R29 respectively in T26.
13. Change taxonomy class of T27 from “Tampering” to “Information Disclosure”.
14. Refine R13 copy used in T11.
15. Change taxonomy class of T13 from “Tampering” to “Spoofing”.
16. Refine R25 copy used in T7 and T15.
17. Remove secondary “Spoofing” taxonomy class from T2.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vcalm/pull/709.html" title="Last updated on Aug 28, 2026, 1:24 PM UTC (54d72ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vcalm/709/24d8fc0...54d72ad.html" title="Last updated on Aug 28, 2026, 1:24 PM UTC (54d72ad)">Diff</a>